### PR TITLE
Store documents in directories based on doc-type

### DIFF
--- a/cmd/docmgr/main.go
+++ b/cmd/docmgr/main.go
@@ -392,6 +392,26 @@ Helpful docs (built-in):
 	}
 	rootCmd.AddCommand(cobraRenumberCmd)
 
+	// Create layout-fix command
+	layoutFixCmd, err := commands.NewLayoutFixCommand()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating layout-fix command: %v\n", err)
+		os.Exit(1)
+	}
+	cobraLayoutFixCmd, err := cli.BuildCobraCommand(layoutFixCmd,
+		cli.WithParserConfig(cli.CobraParserConfig{
+			ShortHelpLayers: []string{layers.DefaultSlug},
+			MiddlewaresFunc: cli.CobraCommandDefaultMiddlewares,
+		}),
+		cli.WithCobraMiddlewaresFunc(cli.CobraCommandDefaultMiddlewares),
+		cli.WithCobraShortHelpLayers(layers.DefaultSlug),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error building layout-fix command: %v\n", err)
+		os.Exit(1)
+	}
+	rootCmd.AddCommand(cobraLayoutFixCmd)
+
 	// Create status command
 	statusCmd, err := commands.NewStatusCommand()
 	if err != nil {

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -42,7 +42,7 @@ func NewAddCommand() (*AddCommand, error) {
 		CommandDescription: cmds.NewCommandDescription(
 			"add",
 			cmds.WithShort("Add a new document to a workspace"),
-			cmds.WithLong(`Creates a new document in the appropriate subdirectory of a workspace.
+			cmds.WithLong(`Creates a new document in the subdirectory named after its doc-type.
 
 Example:
   docmgr add --ticket MEN-3475 --doc-type design-doc --title "Draft Architecture"
@@ -59,7 +59,7 @@ Example:
 				parameters.NewParameterDefinition(
 					"doc-type",
 					parameters.ParameterTypeString,
-					parameters.WithHelp("Document type (per vocabulary; unknown types go to 'various/')"),
+					parameters.WithHelp("Document type (per vocabulary; stored under <doc-type>/ subdir"),
 					parameters.WithRequired(true),
 				),
 				parameters.NewParameterDefinition(
@@ -150,19 +150,8 @@ func (c *AddCommand) RunIntoGlazeProcessor(
 		return fmt.Errorf("failed to find ticket directory: %w", err)
 	}
 
-	// Determine subdirectory based on doc type
-	var subdir string
-	switch settings.DocType {
-	case "design-doc":
-		subdir = "design"
-	case "reference":
-		subdir = "reference"
-	case "playbook":
-		subdir = "playbooks"
-	default:
-		// Accept any vocabulary doc type; place unknown/other types under 'various/'
-		subdir = "various"
-	}
+	// Use doc-type slug directly as subdirectory name
+	subdir := settings.DocType
 
 	// Ensure target subdirectory exists
 	targetDir := filepath.Join(ticketDir, subdir)

--- a/pkg/commands/layout_fix.go
+++ b/pkg/commands/layout_fix.go
@@ -1,0 +1,195 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/adrg/frontmatter"
+	"github.com/go-go-golems/docmgr/pkg/models"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/types"
+)
+
+// LayoutFixCommand moves documents into subdirectories named after their doc-type
+type LayoutFixCommand struct {
+	*cmds.CommandDescription
+}
+
+type LayoutFixSettings struct {
+	Root   string `glazed.parameter:"root"`
+	Ticket string `glazed.parameter:"ticket"`
+	DryRun bool   `glazed.parameter:"dry-run"`
+}
+
+func NewLayoutFixCommand() (*LayoutFixCommand, error) {
+	return &LayoutFixCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"layout-fix",
+			cmds.WithShort("Move docs into <doc-type>/ subdirectories and update links"),
+			cmds.WithLong(`Scans ticket workspaces and moves markdown documents into a subdirectory
+named exactly after their DocType frontmatter (e.g., design-doc/, reference/, playbook/, or custom).
+Skips root-level control files (index.md, tasks.md, changelog.md, README.md).`),
+			cmds.WithFlags(
+				parameters.NewParameterDefinition(
+					"root",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Root directory for docs"),
+					parameters.WithDefault("ttmp"),
+				),
+				parameters.NewParameterDefinition(
+					"ticket",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Limit to a specific ticket"),
+					parameters.WithDefault(""),
+				),
+				parameters.NewParameterDefinition(
+					"dry-run",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Show planned moves without changing files"),
+					parameters.WithDefault(false),
+				),
+			),
+		),
+	}, nil
+}
+
+func (c *LayoutFixCommand) RunIntoGlazeProcessor(
+	ctx context.Context,
+	parsedLayers *layers.ParsedLayers,
+	gp middlewares.Processor,
+) error {
+	settings := &LayoutFixSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, settings); err != nil {
+		return fmt.Errorf("failed to parse settings: %w", err)
+	}
+
+	settings.Root = ResolveRoot(settings.Root)
+	// Collect tickets to process
+	var ticketDirs []string
+	if settings.Ticket != "" {
+		td, err := findTicketDirectory(settings.Root, settings.Ticket)
+		if err != nil {
+			return fmt.Errorf("failed to find ticket directory: %w", err)
+		}
+		ticketDirs = append(ticketDirs, td)
+	} else {
+		entries, err := os.ReadDir(settings.Root)
+		if err != nil {
+			return fmt.Errorf("failed to read root: %w", err)
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				// consider directories with an index.md
+				idx := filepath.Join(settings.Root, e.Name(), "index.md")
+				if _, err := os.Stat(idx); err == nil {
+					ticketDirs = append(ticketDirs, filepath.Join(settings.Root, e.Name()))
+				}
+			}
+		}
+	}
+
+	for _, ticketDir := range ticketDirs {
+		// Walk ticketDir for markdown files
+		renameMap := map[string]string{}
+		err := filepath.WalkDir(ticketDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				// Skip scaffolding dirs
+				name := d.Name()
+				if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") || name == ".meta" || name == "scripts" || name == "sources" || name == "archive" {
+					return nil
+				}
+				return nil
+			}
+			if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+				return nil
+			}
+			// Skip root-level control files
+			dir := filepath.Dir(path)
+			if filepath.Clean(dir) == filepath.Clean(ticketDir) {
+				bn := d.Name()
+				if bn == "index.md" || bn == "README.md" || bn == "tasks.md" || bn == "changelog.md" {
+					return nil
+				}
+			}
+
+			// Determine current first-level directory relative to ticketDir
+			rel, _ := filepath.Rel(ticketDir, path)
+			parts := strings.Split(rel, string(os.PathSeparator))
+			if len(parts) < 1 {
+				return nil
+			}
+
+			// Read frontmatter to get DocType
+			f, err := os.Open(path)
+			if err != nil {
+				return nil
+			}
+			defer func() { _ = f.Close() }()
+			var doc models.Document
+			_, perr := frontmatter.Parse(f, &doc)
+			if perr != nil || doc.DocType == "" {
+				return nil
+			}
+
+			expected := doc.DocType
+			currentTop := parts[0]
+			if currentTop == expected { // already in the right place
+				return nil
+			}
+
+			// Plan move: keep basename, move under expected/
+			newRel := filepath.Join(expected, filepath.Base(path))
+			newAbs := filepath.Join(ticketDir, newRel)
+			if settings.DryRun {
+				row := types.NewRow(
+					types.MRP("ticket", filepath.Base(ticketDir)),
+					types.MRP("from", filepath.ToSlash(rel)),
+					types.MRP("to", filepath.ToSlash(newRel)),
+					types.MRP("status", "would-move"),
+				)
+				return gp.AddRow(ctx, row)
+			}
+
+			if err := os.MkdirAll(filepath.Dir(newAbs), 0755); err != nil {
+				return err
+			}
+			if err := os.Rename(path, newAbs); err != nil {
+				return fmt.Errorf("rename %s -> %s failed: %w", path, newAbs, err)
+			}
+			oldRel := filepath.ToSlash(rel)
+			renameMap[oldRel] = filepath.ToSlash(newRel)
+
+			row := types.NewRow(
+				types.MRP("ticket", filepath.Base(ticketDir)),
+				types.MRP("from", oldRel),
+				types.MRP("to", filepath.ToSlash(newRel)),
+				types.MRP("status", "moved"),
+			)
+			if err := gp.AddRow(ctx, row); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		if !settings.DryRun && len(renameMap) > 0 {
+			if err := updateTicketReferences(ticketDir, renameMap); err != nil {
+				return fmt.Errorf("failed to update references in %s: %w", ticketDir, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+var _ cmds.GlazeCommand = &LayoutFixCommand{}

--- a/pkg/doc/docmgr-cli-guide.md
+++ b/pkg/doc/docmgr-cli-guide.md
@@ -104,10 +104,11 @@ Each ticket gets its own workspace under `ttmp/` (configurable with `--root`). T
 
 - `MEN-4242-normalize-chat-api-paths-and-websocket-lifecycle/`
   - `index.md` (frontmatter and summary)
-  - `design/` (design documents)
+  - `design-doc/` (design documents)
   - `reference/` (contracts, API references)
-  - `playbooks/` (operational steps, QA smoke tests)
-  - `scripts/`, `sources/`, `various/`, `archive/`
+  - `playbook/` (operational steps, QA smoke tests)
+  - `<doc-type>/` (custom types create their own subdir)
+  - `scripts/`, `sources/`, `archive/`
   - `.meta/` (internal data)
 - At root: `_templates/` and `_guidelines/` are scaffolded for consistency
 
@@ -201,7 +202,7 @@ docmgr add --ticket MEN-4242 \
 Notes:
 - `doc-type` values come from your workspace vocabulary (`ttmp/vocabulary.yaml`).
 - If a doc type has a template at `ttmp/_templates/<docType>.md`, its body is rendered automatically.
-- Unknown/other doc types are accepted and placed under `various/` by default (frontmatter `DocType` is still set for filtering).
+- Unknown/other doc types are accepted and stored under a subdirectory named after the doc-type (frontmatter `DocType` is still set for filtering).
 
 ### 4.5 Guidelines
 
@@ -332,7 +333,7 @@ Run `doctor` during development and reviews. It's a safety net to catch drift (s
 docmgr doctor --all --stale-after 30 --fail-on error
 
 # Ignore specific paths using glob patterns
-docmgr doctor --ignore-glob "ttmp/*/design/index.md" --fail-on warning
+docmgr doctor --ignore-glob "ttmp/*/design-doc/index.md" --fail-on warning
 
 # Validate specific ticket
 docmgr doctor --ticket MEN-4242

--- a/pkg/doc/docmgr-how-to-setup.md
+++ b/pkg/doc/docmgr-how-to-setup.md
@@ -190,7 +190,7 @@ docmgr vocab add --category intent --slug temporary \
 docmgr add --ticket MEN-XXXX --doc-type til --title "TIL — WebSocket Reconnection"
 ```
 
-If a template exists at `ttmp/_templates/til.md`, it will be used. Otherwise the doc is created in `various/` with `DocType: til` so it still participates in search and validation.
+If a template exists at `ttmp/_templates/til.md`, it will be used. Otherwise the doc is created under a subdirectory named after its doc-type (for example `til/`) with `DocType: til` so it still participates in search and validation.
 
 ---
 
@@ -316,9 +316,10 @@ repository/
 │   │   ├── index.md
 │   │   ├── tasks.md
 │   │   ├── changelog.md
-│   │   ├── design/
-│   │   ├── reference/
-│   │   └── various/
+│   │   ├── design-doc/        # Created when you add a design-doc
+│   │   ├── reference/         # Created when you add a reference doc
+│   │   ├── playbook/          # Created when you add a playbook
+│   │   └── <doc-type>/        # Any other doc-type creates its own subdir
 │   │
 │   └── TICKET-002-slug/    # Another ticket
 │       └── ...
@@ -329,10 +330,10 @@ repository/
 - Slug from title: lowercase, alphanumerics and dashes only
 - Example: "Chat WebSocket Lifecycle" → `chat-websocket-lifecycle`
 
-**Per-ticket directories created by `create-ticket`:**
+**Per-ticket directories:**
 - `index.md` — Ticket overview
-- `design/`, `reference/`, `playbooks/` — Typed docs
-- `scripts/`, `sources/`, `various/`, `archive/` — Other content
+- Doc-type subdirectories are created on demand by `docmgr add` (for example `design-doc/`, `reference/`, `playbook/`, or custom types like `til/`)
+- `scripts/`, `sources/`, `archive/` — Other content
 - `.meta/` — Internal metadata
 
 ---
@@ -380,7 +381,7 @@ docmgr vocab list --category docTypes
 
 3) **Create template (optional):**
 
-Edit `ttmp/_templates/til.md` with your preferred structure. If no template exists, docs are created in `various/` but still have `DocType: til`.
+Edit `ttmp/_templates/til.md` with your preferred structure. If no template exists, docs are still created and stored under `til/` with `DocType: til`.
 
 4) **Use it:**
 
@@ -413,7 +414,7 @@ docmgr create-ticket --ticket MIGRATE-001 --title "Existing Docs" --topics migra
 
 ```bash
 # Move to appropriate subdirectory
-mv docs/old-design.md ttmp/MIGRATE-001-existing-docs/design/01-old-design.md
+mv docs/old-design.md ttmp/MIGRATE-001-existing-docs/design-doc/01-old-design.md
 mv docs/api-ref.md ttmp/MIGRATE-001-existing-docs/reference/01-api-ref.md
 ```
 
@@ -421,15 +422,15 @@ mv docs/api-ref.md ttmp/MIGRATE-001-existing-docs/reference/01-api-ref.md
 
 ```bash
 # Set ticket
-docmgr meta update --doc ttmp/MIGRATE-001-.../design/01-old-design.md \
+docmgr meta update --doc ttmp/MIGRATE-001-.../design-doc/01-old-design.md \
   --field Ticket --value MIGRATE-001
 
 # Set topics
-docmgr meta update --doc ttmp/MIGRATE-001-.../design/01-old-design.md \
+docmgr meta update --doc ttmp/MIGRATE-001-.../design-doc/01-old-design.md \
   --field Topics --value "backend,api"
 
 # Add summary
-docmgr meta update --doc ttmp/MIGRATE-001-.../design/01-old-design.md \
+docmgr meta update --doc ttmp/MIGRATE-001-.../design-doc/01-old-design.md \
   --field Summary --value "Original API design documentation"
 ```
 
@@ -485,7 +486,7 @@ archive/
 2024-*/
 
 # Ignore specific problematic files
-ttmp/*/design/index.md
+ttmp/*/design-doc/index.md
 ttmp/LEGACY-*/
 
 # Ignore drafts and experiments
@@ -757,7 +758,7 @@ vocabulary: /shared/path/vocabulary.yaml
 
 **Why it's not enforced:**
 - Allows exploratory work (try new topics without approval)
-- Unknown doc-types go to `various/` (flexible)
+- Unknown/custom doc-types create their own `<doc-type>/` subdirectory (flexible)
 - Warnings better than errors (doesn't block progress)
 
 **Think of vocabulary as:**

--- a/pkg/doc/docmgr-how-to-use.md
+++ b/pkg/doc/docmgr-how-to-use.md
@@ -191,10 +191,10 @@ ttmp/MEN-4242-normalize-chat-api-paths-and-websocket-lifecycle/
 ├── index.md        # Ticket overview (you're here)
 ├── tasks.md        # Todo list
 ├── changelog.md    # History of changes
-├── design/         # Design docs will go here
-├── reference/      # Reference docs
-├── playbooks/      # Test procedures
-└── various/        # Other docs
+├── design-doc/     # Created when you add a design-doc
+├── reference/      # Created when you add a reference doc
+├── playbook/       # Created when you add a playbook
+└── <doc-type>/     # Any other doc-type creates its own subdir
 ```
 
 **Understanding index.md:**
@@ -208,7 +208,7 @@ The `index.md` file is your ticket's single entry point. It:
 - Keep index.md body content concise (~50 lines of markdown)
 - Update frontmatter via `docmgr meta update` commands
 - Write Overview, Status, Next Steps in the body content (below frontmatter)
-- Prefer a subdocument-first linking pattern: relate most implementation files to focused subdocuments (design/reference/playbook), and have `index.md` link to those subdocuments instead of listing every file directly.
+- Prefer a subdocument-first linking pattern: relate most implementation files to focused subdocuments (design-doc/reference/playbook), and have `index.md` link to those subdocuments instead of listing every file directly.
 - When relating files (anywhere), always include notes (`--file-note "path:why-this-file-matters"`); file notes are required in our workflow.
 
 > **Smart Default:** Documents you add will automatically inherit topics (`chat,backend,websocket`), owners, and status from the ticket. No need to repeat them!
@@ -230,12 +230,13 @@ docmgr add --ticket MEN-4242 --doc-type playbook --title "Smoke Tests for Chat"
 - Frontmatter fields (Title, Ticket, Topics) are auto-filled
 - Files get numeric prefixes (01-, 02-, 03-) to keep them ordered
 - Topics/owners/status inherited from ticket (no repetition!)
+- The file is stored under a subdirectory named exactly after its doc-type (e.g., `design-doc/`, `reference/`, `playbook/`, or your custom type)
 
 **Common doc types:**
 - `design-doc` — Architecture and design decisions
 - `reference` — API contracts, data schemas, how things work
 - `playbook` — Test procedures, operational runbooks
-- Unknown types? They go to `various/` (flexible!)
+- Custom types are allowed and create their own subdirectory (e.g., `til/`, `analysis/`)
 
 > **Tip:** Want structure guidance? Run: `docmgr guidelines --doc-type design-doc`
 
@@ -403,7 +404,7 @@ Find design context from code files:
 # During code review: "What's the design for this file?"
 $ docmgr search --file backend/api/register.go
 
-MEN-4242/design/01-path-normalization.md — Path Normalization [MEN-4242] ::
+MEN-4242/design-doc/01-path-normalization.md — Path Normalization [MEN-4242] ::
   file=backend/api/register.go note=Registers API routes
 ```
 
@@ -441,7 +442,7 @@ MEN-4242/design/01-path-normalization.md — Path Normalization [MEN-4242] ::
 
 ### Subdocument-first linking
 
-Prefer relating most files to the specific subdocument that explains them (design/reference/playbook) rather than directly to `index.md`. Keep `index.md` minimal and use it to reference those subdocuments.
+Prefer relating most files to the specific subdocument that explains them (design-doc/reference/playbook) rather than directly to `index.md`. Keep `index.md` minimal and use it to reference those subdocuments.
 
 - Why: Subdocuments keep context close to code and prevent `index.md` bloat.
 - How: Add `RelatedFiles` on the subdocument; in `index.md`, add a short link to that subdocument.
@@ -450,7 +451,7 @@ Prefer relating most files to the specific subdocument that explains them (desig
 Example:
 ```bash
 # Relate implementation files to the design doc (preferred)
-docmgr relate --doc ttmp/MEN-4242/design/01-path-normalization-strategy.md \
+docmgr relate --doc ttmp/MEN-4242/design-doc/01-path-normalization-strategy.md \
   --files backend/api/register.go \
   --file-note "backend/api/register.go:Normalization entrypoint and router setup"
 ```
@@ -501,7 +502,7 @@ Changelogs are dated automatically. Keep entries short — mention what changed 
 
 ### Changelog Hygiene (Always Link Files and Provide Notes)
 
-**Best practice:** When you add a changelog entry, always include file notes and also relate the exact files you changed to the relevant subdocument(s) (design/reference/playbook). Keep `index.md` as a concise map that links to those subdocuments. Then validate.
+**Best practice:** When you add a changelog entry, always include file notes and also relate the exact files you changed to the relevant subdocument(s) (design-doc/reference/playbook). Keep `index.md` as a concise map that links to those subdocuments. Then validate.
 
 **The workflow:**
 

--- a/test-api.sh
+++ b/test-api.sh
@@ -30,8 +30,8 @@ curl -s "$API_URL/api/search?type=reference" | python3 -m json.tool | head -30
 echo
 echo
 
-echo "6. Combined search - topic 'chat' + type 'design':"
-curl -s "$API_URL/api/search?topic=chat&type=design" | python3 -m json.tool | head -30
+echo "6. Combined search - topic 'chat' + type 'design-doc':"
+curl -s "$API_URL/api/search?topic=chat&type=design-doc" | python3 -m json.tool | head -30
 echo
 
 echo "=== Tests complete ==="

--- a/test-scenarios/testing-doc-manager/06-doctor-advanced.sh
+++ b/test-scenarios/testing-doc-manager/06-doctor-advanced.sh
@@ -14,9 +14,9 @@ ${DOCMGR} meta update --doc "${INDEX_MD}" --field Topics --value "chat,backend,w
 ${DOCMGR} meta update --doc "${INDEX_MD}" --field RelatedFiles --value \
 "backend/chat/api/register.go,backend/chat/ws/manager.go,web/src/store/api/chatApi.ts,backend/chat/api/does-not-exist.go"
 
-# Create duplicate index inside design/
-mkdir -p "${TICKET_DIR}/design"
-cat > "${TICKET_DIR}/design/index.md" <<'EOF'
+# Create duplicate index inside design-doc/
+mkdir -p "${TICKET_DIR}/design-doc"
+cat > "${TICKET_DIR}/design-doc/index.md" <<'EOF'
 ---
 Title: Design Section Index
 Ticket: MEN-4242
@@ -46,7 +46,7 @@ fi
 # 3) Use ignore-glob to suppress duplicate index, keeping other warnings
 set +e
 ${DOCMGR} doctor --ignore-dir _templates --ignore-dir _guidelines \
-  --ignore-glob "ttmp/*/design/index.md" --fail-on warning
+  --ignore-glob "ttmp/*/design-doc/index.md" --fail-on warning
 DOCTOR_RC2=$?
 set -e
 if [ ${DOCTOR_RC2} -eq 0 ]; then
@@ -59,7 +59,7 @@ ${DOCMGR} meta update --doc "${INDEX_MD}" --field RelatedFiles --value \
 "backend/chat/api/register.go,backend/chat/ws/manager.go,web/src/store/api/chatApi.ts"
 
 # Remove test duplicate index
-rm -f "${TICKET_DIR}/design/index.md"
+rm -f "${TICKET_DIR}/design-doc/index.md"
 
 ${DOCMGR} doctor --ignore-dir _templates --ignore-dir _guidelines --stale-after 30 --fail-on error
 

--- a/test-scenarios/testing-doc-manager/README.md
+++ b/test-scenarios/testing-doc-manager/README.md
@@ -47,6 +47,6 @@ export DOCMGR_PATH=/absolute/path/to/docmgr
 - The ticket workspace will be created under `ttmp/`:
   - `ttmp/MEN-4242-normalize-chat-api-paths-and-websocket-lifecycle/`
 - Doctor now supports:
-  - `--ignore-dir` and `--ignore-glob` to filter out paths (scenario demonstrates `_templates`, `_guidelines` and design/index.md via `--ignore-glob`)
+  - `--ignore-dir` and `--ignore-glob` to filter out paths (scenario demonstrates `_templates`, `_guidelines` and design-doc/index.md via `--ignore-glob`)
   - `--stale-after <days>` to tune staleness threshold
   - `--fail-on {none,warning,error}` to fail the command for CI integration

--- a/test-scenarios/testing-doc-manager/SCENARIO.md
+++ b/test-scenarios/testing-doc-manager/SCENARIO.md
@@ -112,9 +112,9 @@ Optional manual steps:
 - From nested dir (verifies `.ttmp.yaml` resolution):
   - `cd web && docmgr status --summary-only`
 
-- Induce warnings: add unknown topic, add non-existing RelatedFiles, create `design/index.md`
+- Induce warnings: add unknown topic, add non-existing RelatedFiles, create `design-doc/index.md`
 - Show `--fail-on warning` returns nonzero
-- Use `--ignore-glob "ttmp/*/design/index.md"` to suppress duplicate index
+- Use `--ignore-glob "ttmp/*/design-doc/index.md"` to suppress duplicate index
 - Fix metadata and re-run to pass
 
 ## Notes


### PR DESCRIPTION
This pull request implements a new organization structure for documents
by creating subdirectories based on their doc-type. Key changes include:

- Update document handling to store documents directly in subdirectories
  named after their doc-type (e.g., design-doc/, reference/, playbook/).
- Modify the document creation process to automatically create necessary
  subdirectories when adding new documents.
- Enhance the document retrieval system to dynamically scan and include
  doc-type subdirectories, improving the organization and accessibility
  of documents.
- Introduce a new command (layout-fix) to move existing documents into
  their respective subdirectories based on the frontmatter doc-type.