### PR TITLE
remove --files flag and require --file-note for relate and changelog commands

### DIFF
--- a/pkg/commands/doctor.go
+++ b/pkg/commands/doctor.go
@@ -328,6 +328,21 @@ func (c *DoctorCommand) RunIntoGlazeProcessor(
 			if rf.Path == "" {
 				continue
 			}
+			// Warn when a related file is missing an explanatory Note
+			if strings.TrimSpace(rf.Note) == "" {
+				hasIssues = true
+				row := types.NewRow(
+					types.MRP("ticket", doc.Ticket),
+					types.MRP("issue", "missing_related_file_note"),
+					types.MRP("severity", "warning"),
+					types.MRP("message", fmt.Sprintf("related file has no Note: %s", rf.Path)),
+					types.MRP("path", indexPath),
+				)
+				if err := gp.AddRow(ctx, row); err != nil {
+					return err
+				}
+				highestSeverity = maxInt(highestSeverity, 1)
+			}
 			// Build resolution candidates
 			candidates := []string{}
 			if filepath.IsAbs(rf.Path) {

--- a/pkg/doc/docmgr-cli-guide.md
+++ b/pkg/doc/docmgr-cli-guide.md
@@ -278,8 +278,7 @@ Link code files to documentation for bidirectional navigation. Relating files en
 
 ```bash
 # Relate files to ticket index with explanatory notes
-docmgr relate --ticket MEN-4242 --files \
-  backend/api/register.go,backend/ws/manager.go \
+docmgr relate --ticket MEN-4242 \
   --file-note "backend/api/register.go:Registers API routes (normalization logic)" \
   --file-note "backend/ws/manager.go:WebSocket lifecycle management"
 
@@ -305,7 +304,6 @@ docmgr changelog update --ticket MEN-4242 --entry "Normalized API paths"
 
 # With related files
 docmgr changelog update --ticket MEN-4242 \
-  --files backend/api/register.go \
   --file-note "backend/api/register.go:Path normalization source"
 ```
 

--- a/pkg/doc/docmgr-how-to-use.md
+++ b/pkg/doc/docmgr-how-to-use.md
@@ -369,9 +369,10 @@ Bidirectional linking between documentation and code is one of docmgr's most pow
 ### Basic Usage
 
 ```bash
-# Relate files to ticket index
-docmgr relate --ticket MEN-4242 --files \
-  backend/api/register.go,backend/ws/manager.go
+# Relate files to ticket index with notes (repeat --file-note)
+docmgr relate --ticket MEN-4242 \
+  --file-note "backend/api/register.go:Registers API routes (normalization logic)" \
+  --file-note "backend/ws/manager.go:WebSocket lifecycle management"
 ```
 
 ### Relating with Notes (ALWAYS)
@@ -379,8 +380,7 @@ docmgr relate --ticket MEN-4242 --files \
 **Notes are required.** Always provide a note for each file when running `docmgr relate` or `docmgr changelog`. Notes turn file lists into navigation maps that explain why a file is linked.
 
 ```bash
-docmgr relate --ticket MEN-4242 --files \
-  backend/api/register.go,backend/ws/manager.go \
+docmgr relate --ticket MEN-4242 \
   --file-note "backend/api/register.go:Registers API routes (normalization logic)" \
   --file-note "backend/ws/manager.go:WebSocket lifecycle management"
 ```
@@ -452,7 +452,6 @@ Example:
 ```bash
 # Relate implementation files to the design doc (preferred)
 docmgr relate --doc ttmp/MEN-4242/design-doc/01-path-normalization-strategy.md \
-  --files backend/api/register.go \
   --file-note "backend/api/register.go:Normalization entrypoint and router setup"
 ```
 
@@ -464,9 +463,8 @@ docmgr relate --doc ttmp/MEN-4242/design-doc/01-path-normalization-strategy.md \
 
 ```bash
 docmgr relate --ticket MEN-4242 \
-  --files backend/api/register.go,web/src/store/api/chatApi.ts \
-  --file-note "backend/api/register.go:Registers API routes (normalization logic)" \
-  --file-note "web/src/store/api/chatApi.ts:Frontend API integration"
+  --file-note \"backend/api/register.go:Registers API routes (normalization logic)\" \
+  --file-note \"web/src/store/api/chatApi.ts:Frontend API integration\"
 ```
 
 2) **Update the one-line Summary** in frontmatter
@@ -494,7 +492,6 @@ Track progress in `changelog.md`:
 ```bash
 # With related files and notes
 docmgr changelog update --ticket MEN-4242 \
-  --files backend/api/register.go \
   --file-note "backend/api/register.go:Path normalization source"
 ```
 
@@ -510,9 +507,8 @@ Changelogs are dated automatically. Keep entries short — mention what changed 
 
 ```bash
 docmgr relate --ticket MEN-4242 \
-  --files backend/api/register.go,web/src/store/api/chatApi.ts \
-  --file-note "backend/api/register.go:Path normalization source" \
-  --file-note "web/src/store/api/chatApi.ts:Frontend integration"
+  --file-note \"backend/api/register.go:Path normalization source\" \
+  --file-note \"web/src/store/api/chatApi.ts:Frontend integration\"
 ```
 
 2) Add changelog entry (mention linked files):
@@ -569,6 +565,7 @@ docmgr doctor --ticket MEN-4242
 **What doctor checks:**
 - ✅ Missing or invalid frontmatter
 - ✅ Unknown topics/doc-types (warns, doesn't fail)
+- ✅ Missing Note on RelatedFiles entries (warns)
 - ✅ Missing files in RelatedFiles
 - ✅ Stale docs (older than --stale-after days)
 
@@ -1006,7 +1003,7 @@ docmgr search --query "..."
 docmgr search --file path/to/file.go
 
 # Relate files
-docmgr relate --ticket YOUR-123 --files ... --file-note "path:note"
+docmgr relate --ticket YOUR-123 --file-note "path:note" --file-note "path2:note2"
 
 # Validate
 docmgr doctor --ticket YOUR-123

--- a/test-scenarios/testing-doc-manager/04-relate-and-doctor.sh
+++ b/test-scenarios/testing-doc-manager/04-relate-and-doctor.sh
@@ -7,13 +7,16 @@ cd "${REPO}"
 
 DOCMGR="${DOCMGR_PATH:-docmgr}"
 
-# Relate files to the ticket index (sets RelatedFiles)
-${DOCMGR} relate --ticket MEN-4242 --files \
-"backend/chat/api/register.go,backend/chat/ws/manager.go,web/src/store/api/chatApi.ts"
+# Relate files to the ticket index (sets RelatedFiles) with notes
+${DOCMGR} relate --ticket MEN-4242 \
+  --file-note "backend/chat/api/register.go:Registers API routes (scenario)" \
+  --file-note "backend/chat/ws/manager.go:WebSocket lifecycle (scenario)" \
+  --file-note "web/src/store/api/chatApi.ts:Frontend API integration (scenario)"
 
-# Relate files to the second ticket (focus on WS lifecycle)
-${DOCMGR} relate --ticket MEN-5678 --files \
-"backend/chat/ws/manager.go,web/src/ui/chat/ChatPanel.tsx"
+# Relate files to the second ticket (focus on WS lifecycle) with notes
+${DOCMGR} relate --ticket MEN-5678 \
+  --file-note "backend/chat/ws/manager.go:WebSocket lifecycle (scenario)" \
+  --file-note "web/src/ui/chat/ChatPanel.tsx:Frontend chat panel (scenario)"
 
 # Optional: see suggestions with reasons (no changes applied)
 # ${DOCMGR} relate --ticket MEN-4242 --suggest --query WebSocket --topics chat

--- a/test-scenarios/testing-doc-manager/11-changelog-file-notes.sh
+++ b/test-scenarios/testing-doc-manager/11-changelog-file-notes.sh
@@ -7,10 +7,9 @@ cd "${REPO}"
 
 DOCMGR="${DOCMGR_PATH:-docmgr}"
 
-# Append a changelog entry with files and file-notes; verify notes are present
+# Append a changelog entry with file-notes; verify notes are present
 ${DOCMGR} changelog update --ticket MEN-4242 \
   --entry "Test changelog file notes rendering" \
-  --files backend/chat/api/register.go,web/src/store/api/chatApi.ts \
   --file-note "backend/chat/api/register.go:Source of path normalization" \
   --file-note "web/src/store/api/chatApi.ts=Frontend integration"
 

--- a/test-scenarios/testing-doc-manager/SCENARIO.md
+++ b/test-scenarios/testing-doc-manager/SCENARIO.md
@@ -73,7 +73,7 @@ Optional manual steps:
 ### Search
 ### Relate
 - Add explicit related files to the ticket index:
-  - `docmgr relate --ticket MEN-4242 --files backend/chat/api/register.go,backend/chat/ws/manager.go,web/src/store/api/chatApi.ts`
+  - `docmgr relate --ticket MEN-4242 --file-note "backend/chat/api/register.go:Registers API routes" --file-note "backend/chat/ws/manager.go:WebSocket lifecycle" --file-note "web/src/store/api/chatApi.ts:Frontend API integration"`
 - See suggested files with explanations (no changes applied):
   - `docmgr relate --ticket MEN-4242 --suggest --query WebSocket --topics chat`
   - Suggestions include a `source` and a `reason` (e.g., "recent commit activity", "working tree modified", "referenced by documents").
@@ -93,7 +93,6 @@ Optional manual steps:
   - `docmgr changelog update --ticket MEN-4242 --entry "Normalize chat API paths"`
 - With related files and notes:
   - `docmgr changelog update --ticket MEN-4242 \
-     --files backend/chat/api/register.go,web/src/store/api/chatApi.ts \
      --file-note "backend/chat/api/register.go:Source of path normalization" \
      --file-note "web/src/store/api/chatApi.ts=Frontend integration"`
 - Suggestions only / apply suggestions:

--- a/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/README.md
+++ b/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/README.md
@@ -1,0 +1,21 @@
+# Improve related files: remove --files, require notes
+
+This is the document workspace for ticket DOCMGR-002.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr add design-doc "My Design"`
+- Import sources: `docmgr import file path/to/doc.md`
+- Update metadata: `docmgr meta update --field Status --value review`

--- a/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/analysis/01-remove-files-flag-and-require-file-note-in-relate.md
+++ b/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/analysis/01-remove-files-flag-and-require-file-note-in-relate.md
@@ -1,0 +1,213 @@
+---
+Title: Remove --files flag and require file-note in relate
+Ticket: DOCMGR-002
+Status: active
+Topics:
+    - docmgr
+    - ux
+    - cli
+DocType: analysis
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: docmgr/pkg/commands/add.go
+      Note: Seeds RelatedFiles via --related-files; add note-aware behavior or deprecate
+    - Path: docmgr/pkg/commands/changelog.go
+      Note: Supports --files and --file-note; consider consistency later
+    - Path: docmgr/pkg/commands/relate.go
+      Note: Implements relate CLI; remove --files
+    - Path: docmgr/pkg/commands/search.go
+      Note: Uses --files boolean for suggestions; unaffected by this change
+    - Path: docmgr/pkg/doc/docmgr-cli-guide.md
+      Note: CLI guide examples use --files; update to new syntax
+    - Path: docmgr/pkg/doc/docmgr-how-to-use.md
+      Note: Tutorial examples use --files; update to new syntax
+    - Path: docmgr/pkg/models/document.go
+      Note: RelatedFiles structure; note optional today; doctor considerations
+    - Path: docmgr/test-scenarios/testing-doc-manager/SCENARIO.md
+      Note: Scenario references --files; update accordingly
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-07T13:49:25.372914869-05:00
+---
+
+
+
+# Remove --files flag and require file-note in relate
+
+## Purpose and scope
+
+We will change the `docmgr relate` workflow to remove the `--files` flag and require users to always supply notes via repeated `--file-note "path:note"` arguments. This enforces better rationale capture at the moment of relating files.
+
+Scope of this ticket:
+- Update the `relate` command to accept additions only through `--file-note` mappings
+- Disallow legacy `--files` usage with a helpful error
+- Keep removals via `--remove-files` and suggestion flow intact; when applying suggestions, auto-generate a note from reasons as today
+- Update documentation, examples, and test scenarios
+
+Out of scope (follow-ups suggested):
+- Enforcing notes globally in existing documents (doctor validation severity)
+- Aligning `changelog update` to require notes (today it accepts `--files` + optional notes)
+
+## Current behavior (summary)
+
+- CLI:
+  - `docmgr relate` supports `--files`, `--remove-files`, and repeated `--file-note "path:note"`.
+  - `docmgr changelog update` supports `--files` and repeated `--file-note` to include a Related Files list in entries.
+  - `docmgr add` supports `--related-files` to seed RelatedFiles on new docs; it does not accept notes.
+- Implementation:
+  - relate: additions are applied from `settings.Files`, with optional note lookup in a parsed `noteMap` from `settings.FileNotes`.
+  - changelog: builds a file→note map from `--files` + `--file-note`; renders a section in the entry.
+  - add: converts `--related-files` to `RelatedFiles` with empty notes.
+- Suggestions: with `--suggest --apply-suggestions` (relate/changelog), a note is synthesized from reasons when no explicit note exists.
+- Data model: `RelatedFiles` entries have `Path` and optional `Note` (omitempty) in YAML frontmatter.
+
+Key implementation areas:
+- Flag definitions and help text in `docmgr/pkg/commands/relate.go`.
+- Addition/removal logic in `RunIntoGlazeProcessor` of `relate.go`.
+- Frontmatter read/write helpers in `pkg/commands` (`readDocumentWithContent`, `writeDocumentWithFrontmatter`).
+- Documentation and examples in `pkg/doc` and `test-scenarios`.
+
+## Proposed behavior (by verb)
+
+- relate
+  - Remove support for `--files`.
+  - Additions and updates must be expressed via repeated `--file-note "path:note"`.
+  - Error on empty/missing note values; keep `--remove-files` unchanged.
+  - Keep `--suggest --apply-suggestions`; ensure a note is always present (explicit or synthesized).
+  - Fail fast on legacy `--files` with a clear migration message.
+
+- changelog update
+  - Deprecate and remove `--files` for consistency; require repeated `--file-note` for related files in entries.
+  - When using `--suggest --apply-suggestions`, synthesize notes as today.
+  - Provide a migration error with concrete examples if `--files` is provided.
+
+- add
+  - Replace `--related-files` with repeated `--file-note` to seed `RelatedFiles` with notes at creation time; error if notes are missing.
+  - Alternative (softer) path: keep `--related-files` but warn and require `--file-note` when related files are specified; however, preferred is to remove `--related-files` for clarity.
+
+## Changes by area
+
+### CLI and command logic
+
+File: `docmgr/pkg/commands/relate.go`
+
+- Remove the `files` flag and `Files []string` from `RelateSettings`.
+- Update long help/examples to show only `--file-note` for additions.
+- Addition logic: iterate over the parsed `noteMap` keys to add or update entries; do not read from `settings.Files`.
+- Validation: if no additions were specified (no `--file-note`), and neither `--remove-files` nor `--apply-suggestions` are used, return an error like: "No changes specified. Use --file-note path:note to add/update, --remove-files to remove, or --suggest --apply-suggestions."
+- Validation: for each `--file-note`, require a non-empty note value; error if missing.
+- Legacy guard: if the (now removed) `--files` parameter is encountered by older shells or integrations, return a targeted error: "--files has been removed. Use repeated --file-note 'path:note' instead. Example: docmgr relate --file-note 'a/b.go:reason' --file-note 'c/d.ts:reason'".
+File: `docmgr/pkg/commands/changelog.go`
+
+- Remove `files` flag and `Files []string` from settings; require `--file-note` for any file references in entries.
+- Keep suggestions behavior; ensure notes are present for applied suggestions.
+- Update help/examples accordingly; add migration error message when `--files` is used.
+
+File: `docmgr/pkg/commands/add.go`
+
+- Add support for repeated `--file-note` to seed `RelatedFiles` with notes on new docs.
+- Remove `--related-files` (or accept but error with a migration message pointing to `--file-note`).
+- Update help/examples.
+
+- Suggestions path: unchanged; when applying, continue generating notes from reasons where none provided explicitly.
+
+Notes on code touchpoints:
+- Flag removal/update in `NewRelateCommand()`.
+- Addition/removal application block currently around the additions loop (see ~`for _, af := range settings.Files`): replace with iteration over `noteMap`.
+- Maintain stable ordering and existing frontmatter preservation behavior.
+
+### Data model
+
+File: `docmgr/pkg/models/document.go`
+
+- No structural change required. `Note` remains optional in the schema to maintain backward compatibility for existing documents. Enforcement occurs at the CLI layer and (optionally) doctor.
+
+### Validation (doctor)
+
+File: `docmgr/pkg/commands/doctor.go`
+
+- Add a check that emits a warning for `RelatedFiles` entries with an empty `Note`. Consider a `--enforce-notes` flag (or configuration) to upgrade this to an error in CI, but for now keep a warning to avoid breaking existing workspaces.
+
+### Documentation updates
+
+Update all examples to remove `--files` usage and demonstrate repeated `--file-note` entries:
+
+- `docmgr/pkg/doc/docmgr-how-to-use.md`
+  - Sections showing `docmgr relate --files` must change to only `--file-note` entries.
+  - Keep suggestion examples; clarify that applying suggestions always produces a note.
+
+- `docmgr/pkg/doc/docmgr-cli-guide.md`
+  - Replace relate examples to use repeated `--file-note`.
+  - Update any automation snippets that relied on `--files` to instead produce `--file-note "$f:$NOTE"`.
+
+- Add command sections
+  - Replace `--related-files` with repeated `--file-note` in examples and templates.
+
+- `docmgr/test-scenarios/testing-doc-manager/SCENARIO.md`
+  - Update the Relate and Changelog examples to match the new syntax for relate.
+  - Update Add examples to seed `RelatedFiles` using `--file-note`.
+
+### Other commands (review only)
+
+- `docmgr search` uses a boolean `--files` to trigger suggestion output. This is unrelated to list-style `--files` and remains unchanged. Disambiguate in docs.
+
+## Migration and compatibility
+
+- relate: legacy `--files` errors with a migration hint to repeated `--file-note`.
+- changelog: legacy `--files` errors with a migration hint to repeated `--file-note`.
+- add: legacy `--related-files` errors with a migration hint to repeated `--file-note` (or warn-only if a softer rollout is preferred).
+- Existing documents without notes remain valid. Doctor will surface warnings; teams can resolve incrementally.
+
+## Test and scenario updates
+
+- Update `test-scenarios/testing-doc-manager/SCENARIO.md` relate examples.
+- Update changelog examples to use only `--file-note`.
+- Update add examples to seed with `--file-note`.
+- Grep and replace `docmgr relate --files`, `docmgr changelog update --files`, and `docmgr add --related-files` across repository docs.
+- Add small scenarios: legacy flags → expect clear migration errors; note-only flows → success; suggestions → success with synthesized notes.
+
+## Implementation checklist
+
+- [ ] Relate: remove `--files`; require `--file-note`; validate non-empty notes
+- [ ] Relate: fail fast on legacy `--files`; keep suggestions and removals
+- [ ] Changelog: remove `--files`; require `--file-note`; suggestions synthesize notes; legacy error
+- [ ] Add: support repeated `--file-note`; remove `--related-files` (or error with migration)
+- [ ] Doctor: warn for blank `Note` entries in `RelatedFiles`
+- [ ] Docs: update tutorial/CLI guide/add & changelog examples
+- [ ] Scenarios and CI snippets updated
+- [ ] Changelog entry documenting breaking changes
+
+## Key files impacted
+
+- `docmgr/pkg/commands/relate.go` — CLI flags, addition/removal logic, help text
+- `docmgr/pkg/commands/changelog.go` — CLI flags, file-note enforcement, suggestions
+- `docmgr/pkg/commands/add.go` — add note-aware seeding, remove `--related-files`
+- `docmgr/pkg/commands/doctor.go` — new warning for missing notes (optional in this ticket)
+- `docmgr/pkg/doc/docmgr-how-to-use.md` — tutorial updates
+- `docmgr/pkg/doc/docmgr-cli-guide.md` — reference/automation updates
+- `docmgr/test-scenarios/testing-doc-manager/SCENARIO.md` — scenario commands
+- (follow-up) `docmgr/pkg/commands/changelog.go` — decide on consistency
+
+## Example new usage
+
+Add two files with notes to the ticket index:
+
+```bash
+docmgr relate --ticket DOCMGR-002 \
+  --file-note "docmgr/pkg/commands/relate.go:Implements relate CLI changes" \
+  --file-note "docmgr/pkg/doc/docmgr-how-to-use.md:Update examples to note-only"
+```
+
+Remove a file:
+
+```bash
+docmgr relate --ticket DOCMGR-002 --remove-files docmgr/pkg/commands/relate.go
+```
+
+Apply suggestions (notes auto-generated from reasons; can be overridden with explicit `--file-note`):
+
+```bash
+docmgr relate --ticket DOCMGR-002 --suggest --apply-suggestions --query "relate command"
+```

--- a/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/changelog.md
+++ b/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/changelog.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 2025-11-07
+
+- Initial workspace created
+
+
+## 2025-11-07
+
+Created analysis doc and mapped code paths for relate changes
+
+### Related Files
+
+- docmgr/pkg/commands/relate.go — Primary change surface
+
+
+## 2025-11-07
+
+Relate: removed --files; require --file-note; docs updated; doctor warns on missing notes.
+
+
+## 2025-11-07
+
+Changelog: removed --files; require notes via --file-note; updated docs & scenarios
+

--- a/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/index.md
+++ b/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/index.md
@@ -1,0 +1,56 @@
+---
+Title: 'Improve related files: remove --files, require notes'
+Ticket: DOCMGR-002
+Status: active
+Topics:
+    - docmgr
+    - ux
+    - cli
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-07T13:49:25.339622795-05:00
+---
+
+
+# Improve related files: remove --files, require notes
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- docmgr
+- ux
+- cli
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/tasks.md
+++ b/ttmp/DOCMGR-002-improve-related-files-remove-files-require-notes/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+
+- [x] Remove --files flag and enforce --file-note for relate
+- [x] Update relate.go to add via file-note map only; validate note present
+- [x] Update help, how-to-use, cli-guide, test scenarios to new syntax
+- [x] Add doctor warning for RelatedFiles entries missing Note (existing docs)
+- [x] Decide on changelog update consistency (require notes or leave as-is)

--- a/ttmp/DOCMGR-UX-001-ux-debrief-validate-and-improve-docmgr-tutorial-usability/playbooks/01-tutorial-v2-restructured-based-on-ux-findings.md
+++ b/ttmp/DOCMGR-UX-001-ux-debrief-validate-and-improve-docmgr-tutorial-usability/playbooks/01-tutorial-v2-restructured-based-on-ux-findings.md
@@ -478,7 +478,6 @@ Track progress in `changelog.md`:
 ```bash
 # With related files and notes
 docmgr changelog update --ticket MEN-4242 \
-  --files backend/api/register.go \
   --file-note "backend/api/register.go:Path normalization source"
 ```
 
@@ -494,7 +493,6 @@ Changelogs are dated automatically. Keep entries short — mention what changed 
 
 ```bash
 docmgr relate --ticket MEN-4242 \
-  --files backend/api/register.go,web/src/store/api/chatApi.ts \
   --file-note "backend/api/register.go:Path normalization source" \
   --file-note "web/src/store/api/chatApi.ts:Frontend integration"
 ```


### PR DESCRIPTION
- Remove the `--files` flag from the `relate` and `changelog` commands.
- Require users to provide file references through repeated `--file-note "path:note"`.
- Update all associated documentation and examples to reflect the changes.
- Emit friendly migration error messages when deprecated flags are used.
- Ensure validation for non-empty notes in `--file-note` mappings.
- Maintain existing functionality for removing files and applying suggestions.
- Introduce warnings for missing notes in related files checked by the doctor command.