### PR TITLE
Add tests for appendNote

### DIFF
--- a/pkg/commands/relate_test.go
+++ b/pkg/commands/relate_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import "testing"
+
+func TestAppendNote(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		existing  string
+		addition  string
+		want      string
+		didChange bool
+	}{
+		{
+			name:      "adds note when existing empty",
+			existing:  "",
+			addition:  "added note",
+			want:      "added note",
+			didChange: true,
+		},
+		{
+			name:      "trims addition and avoids duplicates",
+			existing:  "first note",
+			addition:  "  first note  ",
+			want:      "first note",
+			didChange: false,
+		},
+		{
+			name:      "appends with newline",
+			existing:  "first note",
+			addition:  "second note",
+			want:      "first note\nsecond note",
+			didChange: true,
+		},
+		{
+			name:      "preserves trailing newline",
+			existing:  "first note\n",
+			addition:  "second note",
+			want:      "first note\nsecond note",
+			didChange: true,
+		},
+		{
+			name:      "skips empty addition",
+			existing:  "first note",
+			addition:  "   ",
+			want:      "first note",
+			didChange: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, changed := appendNote(tc.existing, tc.addition)
+			if got != tc.want {
+				t.Fatalf("appendNote() = %q, want %q", got, tc.want)
+			}
+			if changed != tc.didChange {
+				t.Fatalf("appendNote() change = %v, want %v", changed, tc.didChange)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a table-driven unit test for `appendNote` so multi-line note updates and duplicate suppression are covered

## Testing
- `go test ./...`
- `go build ./cmd/docmgr`
- `DOCBIN=/workspace/docmgr/docmgr; TEST_ROOT=/tmp/docmgr-relate-test; rm -rf "$TEST_ROOT" && mkdir -p "$TEST_ROOT" && cd "$TEST_ROOT" && $DOCBIN init --seed-vocabulary && $DOCBIN create-ticket --ticket TEST-1 --title "Relate duplicates" --topics backend && $DOCBIN relate --ticket TEST-1 --file-note "pkg/foo.go:first note" && $DOCBIN relate --ticket TEST-1 --file-note "pkg/foo.go:second note"`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a8b64aa4c8332aec10323bf99e544)