### PR TITLE
fix doc verbs and update documentation

### DIFF
--- a/cmd/docmgr/cmds/doc/list.go
+++ b/cmd/docmgr/cmds/doc/list.go
@@ -12,9 +12,15 @@ func newListCommand() (*cobra.Command, error) {
 	if err != nil {
 		return nil, err
 	}
-	return common.BuildCommand(
+	cobraCmd, err := common.BuildCommand(
 		cmd,
 		cli.WithDualMode(true),
 		cli.WithGlazeToggleFlag("with-glaze-output"),
 	)
+	if err != nil {
+		return nil, err
+	}
+	// Keep backward-compatibility: allow `docmgr doc docs`
+	cobraCmd.Aliases = append(cobraCmd.Aliases, "docs")
+	return cobraCmd, nil
 }

--- a/cmd/docmgr/cmds/tasks/tasks.go
+++ b/cmd/docmgr/cmds/tasks/tasks.go
@@ -5,8 +5,9 @@ import "github.com/spf13/cobra"
 // Attach registers the tasks command tree under the root (docmgr tasks ...).
 func Attach(root *cobra.Command) error {
 	tasksCmd := &cobra.Command{
-		Use:   "tasks",
-		Short: "Manage ticket task lists",
+		Use:     "task",
+		Aliases: []string{"tasks"},
+		Short:   "Manage ticket task lists",
 	}
 
 	listCmd, err := newListCommand()

--- a/cmd/docmgr/cmds/ticket/list.go
+++ b/cmd/docmgr/cmds/ticket/list.go
@@ -12,9 +12,15 @@ func newListCommand() (*cobra.Command, error) {
 	if err != nil {
 		return nil, err
 	}
-	return common.BuildCommand(
+	cobraCmd, err := common.BuildCommand(
 		cmd,
 		cli.WithDualMode(true),
 		cli.WithGlazeToggleFlag("with-glaze-output"),
 	)
+	if err != nil {
+		return nil, err
+	}
+	// Allow `docmgr ticket list` as an alias to `docmgr ticket tickets`
+	cobraCmd.Aliases = append(cobraCmd.Aliases, "list")
+	return cobraCmd, nil
 }

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -269,6 +269,22 @@ func (c *AddCommand) RunIntoGlazeProcessor(
 		return fmt.Errorf("failed to write document: %w", err)
 	}
 
+	// After creating the document, print the guidelines for the selected doc type.
+	// Prefer workspace-overridden guidelines under <root>/_guidelines/<doc-type>.md,
+	// falling back to embedded defaults when not present.
+	{
+		guidelinePath := filepath.Join(settings.Root, "_guidelines", fmt.Sprintf("%s.md", settings.DocType))
+		if b, err := os.ReadFile(guidelinePath); err == nil {
+			fmt.Printf("\n===== Guidelines for %s =====\n\n%s\n", settings.DocType, string(b))
+		} else {
+			if guideline, ok := GetGuideline(settings.DocType); ok {
+				fmt.Printf("\n===== Guidelines for %s =====\n\n%s\n", settings.DocType, guideline)
+			} else {
+				fmt.Printf("\n(No guidelines found for doc-type %s. Use 'docmgr doc guidelines --list' to see available types.)\n", settings.DocType)
+			}
+		}
+	}
+
 	row := types.NewRow(
 		types.MRP("ticket", settings.Ticket),
 		types.MRP("doc_type", settings.DocType),

--- a/pkg/commands/list_docs.go
+++ b/pkg/commands/list_docs.go
@@ -32,7 +32,7 @@ type ListDocsSettings struct {
 func NewListDocsCommand() (*ListDocsCommand, error) {
 	return &ListDocsCommand{
 		CommandDescription: cmds.NewCommandDescription(
-			"docs",
+			"list",
 			cmds.WithShort("List individual documents"),
 			cmds.WithLong(`Lists all individual documents across all workspaces.
 
@@ -41,6 +41,7 @@ Columns:
 
 Examples:
   # Human output
+  docmgr doc list
   docmgr list docs
   docmgr list docs --ticket MEN-3475
   docmgr list docs --doc-type design-doc

--- a/pkg/doc/doc.go
+++ b/pkg/doc/doc.go
@@ -6,6 +6,7 @@
 // The embedded files include:
 //   - docmgr-how-to-use.md: Quick start and usage guide
 //   - docmgr-how-to-setup.md: Initial setup instructions
+//   - how-to-work-on-any-ticket.md: Checklist for taking over any ticket
 //   - docmgr-cli-guide.md: Complete CLI reference
 //   - templates-and-guidelines.md: Document templates and guidelines
 //   - docmgr-ci-automation.md: CI/CD integration guide

--- a/pkg/doc/docmgr-cli-guide.md
+++ b/pkg/doc/docmgr-cli-guide.md
@@ -42,7 +42,7 @@ docmgr vocab list  # Should show seeded topics (chat, backend, websocket)
 
 # 4) Create a ticket workspace under ttmp/
 # Creates a dedicated directory with index, tasks, changelog, and standard subfolders.
-docmgr create-ticket --ticket MEN-4242 \
+docmgr ticket create-ticket --ticket MEN-4242 \
   --title "Normalize chat API paths and WebSocket lifecycle" \
   --topics chat,backend,websocket
 
@@ -50,9 +50,9 @@ By default the workspace lives under `ttmp/YYYY/MM/DD/<ticket>-<slug>/`. Overrid
 
 # 5) Add documents
 # Add a design doc, a reference doc, and a playbook to start capturing context.
-docmgr add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
-docmgr add --ticket MEN-4242 --doc-type reference  --title "Chat WebSocket Lifecycle"
-docmgr add --ticket MEN-4242 --doc-type playbook   --title "Smoke Tests for Chat"
+docmgr doc add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
+docmgr doc add --ticket MEN-4242 --doc-type reference  --title "Chat WebSocket Lifecycle"
+docmgr doc add --ticket MEN-4242 --doc-type playbook   --title "Smoke Tests for Chat"
 
 # 6) Update metadata on the ticket index
 # Owners and Summary improve discoverability; RelatedFiles enable reverse lookup.
@@ -80,11 +80,11 @@ Examples:
 
 ```bash
 # Human-readable (default)
-docmgr list tickets
+docmgr ticket list
 
 # Structured
-docmgr list tickets --with-glaze-output --output json
-docmgr search --query websocket --with-glaze-output --output yaml
+docmgr ticket list --with-glaze-output --output json
+docmgr doc search --query websocket --with-glaze-output --output yaml
 ```
 
 ## 3. Core Concepts
@@ -174,7 +174,7 @@ Creates the `ttmp/` directory if missing, and scaffolds `_templates/` and `_guid
 
 Run this when you start a ticket. It creates a consistent place to capture thinking and decisions.
 ```bash
-docmgr create-ticket --ticket MEN-4242 \
+docmgr ticket create-ticket --ticket MEN-4242 \
   --title "Normalize chat API paths and WebSocket lifecycle" \
   --topics chat,backend,websocket \
   [--force]
@@ -186,11 +186,11 @@ Creates the ticket directory with `index.md`, and `tasks.md`/`changelog.md` unde
 
 Create additional documents as needed. Use short, descriptive titles; you can refine content later.
 ```bash
-docmgr add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
-docmgr add --ticket MEN-4242 --doc-type til        --title "TIL — Hydration end-to-end"
+docmgr doc add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
+docmgr doc add --ticket MEN-4242 --doc-type til        --title "TIL — Hydration end-to-end"
 
 # Optional overrides (taken from ticket by default)
-docmgr add --ticket MEN-4242 \
+docmgr doc add --ticket MEN-4242 \
   --doc-type til \
   --title "TIL conv-id vs run-id hydration curl debugging 2025-11-03" \
   --topics hydration,persistence,conversation,bug \
@@ -212,10 +212,10 @@ Notes:
 Guidelines provide structure and “what good looks like” for each doc type. They help new contributors produce consistent, reviewable docs.
 ```bash
 # Human-readable guideline text
-docmgr guidelines --doc-type design-doc
+docmgr doc guidelines --doc-type design-doc
 
 # Structured output (for tooling)
-docmgr guidelines --doc-type design-doc --with-glaze-output --output json
+docmgr doc guidelines --doc-type design-doc --with-glaze-output --output json
 ```
 
 Prints the guideline text for the given type. Files in `ttmp/_guidelines/` override embedded defaults.
@@ -238,8 +238,8 @@ Supported fields: Title, Ticket, Status, Topics, DocType, Intent, Owners, Relate
 
 Use listing commands to navigate by ticket. This is useful in reviews and when returning to paused work.
 ```bash
-docmgr list tickets [--ticket MEN-4242]
-docmgr list docs    --ticket MEN-4242
+docmgr ticket list [--ticket MEN-4242]
+docmgr doc list    --ticket MEN-4242
 ```
 
 ### 4.8 Search (Content + Metadata)
@@ -247,30 +247,30 @@ docmgr list docs    --ticket MEN-4242
 Search supports both content queries and metadata filters. Reverse lookups (`--file`, `--dir`) help you find docs from code paths; `--external-source` helps find docs tied to external references. Date filters surface recent activity.
 ```bash
 # Content search
-docmgr search --query "WebSocket" --ticket MEN-4242
+docmgr doc search --query "WebSocket" --ticket MEN-4242
 
 # Metadata filters
-docmgr search --ticket MEN-4242 --topics websocket,backend --doc-type design-doc
+docmgr doc search --ticket MEN-4242 --topics websocket,backend --doc-type design-doc
 
 # Reverse lookup by file or directory
-docmgr search --file backend/chat/api/register.go
-docmgr search --dir  web/src/store/api/
+docmgr doc search --file backend/chat/api/register.go
+docmgr doc search --dir  web/src/store/api/
 
 # External source reference
-docmgr search --external-source "https://example.com/ws-lifecycle"
+docmgr doc search --external-source "https://example.com/ws-lifecycle"
 
 # Date filters (relative and absolute)
-docmgr search --updated-since "2 weeks ago" --ticket MEN-4242
-docmgr search --since "last month" --until "today"
+docmgr doc search --updated-since "2 weeks ago" --ticket MEN-4242
+docmgr doc search --since "last month" --until "today"
 
 # File suggestions (heuristics: related files, git, ripgrep/grep)
-docmgr search --ticket MEN-4242 --topics chat --files
+docmgr doc search --ticket MEN-4242 --topics chat --files
 
 # Relate changed files from git status (modified, staged, untracked)
-docmgr relate --ticket MEN-4242 --suggest --from-git
+docmgr doc relate --ticket MEN-4242 --suggest --from-git
 
 # Apply changed files directly to the ticket index with notes
-docmgr relate --ticket MEN-4242 --suggest --from-git --apply-suggestions
+docmgr doc relate --ticket MEN-4242 --suggest --from-git --apply-suggestions
 ```
 
 Relative date formats supported include: `today`, `yesterday`, `last week`, `this month`, `last month`, `2 weeks ago`, as well as ISO-like absolute dates (for example, `2025-01-01`).
@@ -281,18 +281,18 @@ Link code files to documentation for bidirectional navigation. Relating files en
 
 ```bash
 # Relate files to ticket index with explanatory notes
-docmgr relate --ticket MEN-4242 \
+docmgr doc relate --ticket MEN-4242 \
   --file-note "backend/api/register.go:Registers API routes (normalization logic)" \
   --file-note "backend/ws/manager.go:WebSocket lifecycle management"
 
 # Suggest files from git changes
-docmgr relate --ticket MEN-4242 --suggest --from-git
+docmgr doc relate --ticket MEN-4242 --suggest --from-git
 
 # Apply suggestions automatically
-docmgr relate --ticket MEN-4242 --suggest --from-git --apply-suggestions
+docmgr doc relate --ticket MEN-4242 --suggest --from-git --apply-suggestions
 
 # Remove files
-docmgr relate --ticket MEN-4242 --remove-files old/file.go
+docmgr doc relate --ticket MEN-4242 --remove-files old/file.go
 ```
 
 Notes explain WHY each file matters, turning file lists into navigation maps.
@@ -316,13 +316,13 @@ Manage concrete steps in `tasks.md`:
 
 ```bash
 # Add tasks
-docmgr tasks add --ticket MEN-4242 --text "Update API docs"
+docmgr task add --ticket MEN-4242 --text "Update API docs"
 
 # Check off tasks
-docmgr tasks check --ticket MEN-4242 --id 1,2
+docmgr task check --ticket MEN-4242 --id 1,2
 
 # List tasks
-docmgr tasks list --ticket MEN-4242
+docmgr task list --ticket MEN-4242
 ```
 
 ### 4.12 Doctor (Validation)
@@ -366,33 +366,33 @@ go build -o /tmp/docmgr ./cmd/docmgr
 # Create temp root and seed a workspace
 ROOT=$(mktemp -d /tmp/docmgr-tests-XXXXXXXX)
 /tmp/docmgr init --root "$ROOT"
-/tmp/docmgr create-ticket --ticket TST-1000 --title "Dual Mode Test" --topics demo,test --root "$ROOT"
-/tmp/docmgr add  --ticket TST-1000 --doc-type design-doc --title "Design One" --root "$ROOT"
+/tmp/docmgr ticket create-ticket --ticket TST-1000 --title "Dual Mode Test" --topics demo,test --root "$ROOT"
+/tmp/docmgr doc add  --ticket TST-1000 --doc-type design-doc --title "Design One" --root "$ROOT"
 
 # list tickets
-/tmp/docmgr list tickets --root "$ROOT"
-/tmp/docmgr list tickets --root "$ROOT" --with-glaze-output --output json
+/tmp/docmgr ticket list --root "$ROOT"
+/tmp/docmgr ticket list --root "$ROOT" --with-glaze-output --output json
 
 # list docs
-/tmp/docmgr list docs --root "$ROOT" --ticket TST-1000
-/tmp/docmgr list docs --root "$ROOT" --ticket TST-1000 --with-glaze-output --output table
+/tmp/docmgr doc list --root "$ROOT" --ticket TST-1000
+/tmp/docmgr doc list --root "$ROOT" --ticket TST-1000 --with-glaze-output --output table
 
 # status
 /tmp/docmgr status --root "$ROOT"
 /tmp/docmgr status --root "$ROOT" --with-glaze-output --output json
 
 # guidelines
-/tmp/docmgr guidelines --list --root "$ROOT"
-/tmp/docmgr guidelines --doc-type design-doc --root "$ROOT"
-/tmp/docmgr guidelines --doc-type design-doc --root "$ROOT" --with-glaze-output --output json
+/tmp/docmgr doc guidelines --list --root "$ROOT"
+/tmp/docmgr doc guidelines --doc-type design-doc --root "$ROOT"
+/tmp/docmgr doc guidelines --doc-type design-doc --root "$ROOT" --with-glaze-output --output json
 
 # tasks list
-/tmp/docmgr tasks list --ticket TST-1000 --root "$ROOT"
-/tmp/docmgr tasks list --ticket TST-1000 --root "$ROOT" --with-glaze-output --output csv
+/tmp/docmgr task list --ticket TST-1000 --root "$ROOT"
+/tmp/docmgr task list --ticket TST-1000 --root "$ROOT" --with-glaze-output --output csv
 
 # search
-/tmp/docmgr search --root "$ROOT" --ticket TST-1000 --query workspace
-/tmp/docmgr search --root "$ROOT" --ticket TST-1000 --query workspace --with-glaze-output --output yaml
+/tmp/docmgr doc search --root "$ROOT" --ticket TST-1000 --query workspace
+/tmp/docmgr doc search --root "$ROOT" --ticket TST-1000 --query workspace --with-glaze-output --output yaml
 
 # cleanup (optional)
 rm -rf "$ROOT"

--- a/pkg/doc/docmgr-how-to-setup.md
+++ b/pkg/doc/docmgr-how-to-setup.md
@@ -59,8 +59,8 @@ Setup-specific terms used in this guide:
 
 - **Docs root** — The `ttmp/` directory containing all documentation (default location)
 - **Vocabulary** — Central `vocabulary.yaml` defining valid topics, doc types, and intents
-- **Templates** — Markdown files in `_templates/` used by `docmgr add` to scaffold new docs
-- **Guidelines** — Writing guidance in `_guidelines/` shown via `docmgr guidelines`
+- **Templates** — Markdown files in `_templates/` used by `docmgr doc add` to scaffold new docs
+- **Guidelines** — Writing guidance in `_guidelines/` shown via `docmgr doc guidelines`
 - **.ttmp.yaml** — Optional config file for custom root paths or multi-repo setups
 - **Slugification** — How ticket titles become directory names (lowercase, dashes, normalized)
 
@@ -122,16 +122,16 @@ docmgr status --summary-only
 docmgr vocab list
 
 # See templates
-docmgr list tickets  # Will be empty but proves root exists
+docmgr ticket list  # Will be empty but proves root exists
 ```
 
 **Understanding what was created:**
 
 - **vocabulary.yaml** — Defines valid topics (backend, frontend, websocket), doc types (design-doc, reference, playbook), and intents (long-term). Used for validation warnings, not enforcement.
 
-- **_templates/** — Contains markdown templates for each doc type with placeholders (`{{TITLE}}`, `{{TICKET}}`, etc.) that `docmgr add` fills automatically.
+- **_templates/** — Contains markdown templates for each doc type with placeholders (`{{TITLE}}`, `{{TICKET}}`, etc.) that `docmgr doc add` fills automatically.
 
-- **_guidelines/** — Writing guidance shown via `docmgr guidelines --doc-type TYPE`. Customize these to encode your team's standards.
+- **_guidelines/** — Writing guidance shown via `docmgr doc guidelines --doc-type TYPE`. Customize these to encode your team's standards.
 
 - **.docmgrignore** — Like `.gitignore` but for docmgr validation. Excludes `.git/`, `_templates/`, `_guidelines/` by default.
 
@@ -187,7 +187,7 @@ docmgr vocab add --category intent --slug temporary \
 
 ```bash
 # After adding 'til' to vocabulary
-docmgr add --ticket MEN-XXXX --doc-type til --title "TIL — WebSocket Reconnection"
+docmgr doc add --ticket MEN-XXXX --doc-type til --title "TIL — WebSocket Reconnection"
 ```
 
 If a template exists at `ttmp/_templates/til.md`, it will be used. Otherwise the doc is created under a subdirectory named after its doc-type (for example `til/`) with `DocType: til` so it still participates in search and validation.
@@ -209,13 +209,13 @@ Templates are in `ttmp/_templates/<docType>.md` and use placeholders:
 - `{{OWNERS}}` — YAML-formatted owners array
 - `{{SUMMARY}}` — Summary text
 
-**When you run `docmgr add`, these placeholders are automatically filled.**
+**When you run `docmgr doc add`, these placeholders are automatically filled.**
 
 **Customize templates** by editing files in `_templates/`. Use `docmgr init --force` to re-scaffold if you want to reset to defaults.
 
 ### Guidelines
 
-Guidelines are shown via `docmgr guidelines --doc-type TYPE` and help writers understand:
+Guidelines are shown via `docmgr doc guidelines --doc-type TYPE` and help writers understand:
 - What sections to include
 - What quality standards to meet
 - What reviewers look for
@@ -223,9 +223,9 @@ Guidelines are shown via `docmgr guidelines --doc-type TYPE` and help writers un
 **Preview guidelines:**
 
 ```bash
-docmgr guidelines --doc-type design-doc
-docmgr guidelines --doc-type reference
-docmgr guidelines --list  # Show all available types
+docmgr doc guidelines --doc-type design-doc
+docmgr doc guidelines --doc-type reference
+docmgr doc guidelines --list  # Show all available types
 ```
 
 **Customize guidelines** by editing files in `_guidelines/`.
@@ -240,9 +240,9 @@ docmgr guidelines --list  # Show all available types
 ✅ **Milestone: Repository is Set Up!**
 
 Your team can now:
-- Create tickets with `docmgr create-ticket`
-- Add docs with `docmgr add`
-- Search with `docmgr search`
+- Create tickets with `docmgr ticket create-ticket`
+- Add docs with `docmgr doc add`
+- Search with `docmgr doc search`
 
 **What's next?**
 - Set up CI validation (see separate **CI and Automation Guide**)
@@ -332,7 +332,7 @@ repository/
 
 **Per-ticket directories:**
 - `index.md` — Ticket overview
-- Doc-type subdirectories are created on demand by `docmgr add` (for example `design-doc/`, `reference/`, `playbook/`, or custom types like `til/`)
+- Doc-type subdirectories are created on demand by `docmgr doc add` (for example `design-doc/`, `reference/`, `playbook/`, or custom types like `til/`)
 - `scripts/`, `sources/`, `archive/` — Other content
 - `.meta/` — Internal metadata
 
@@ -386,7 +386,7 @@ Edit `ttmp/_templates/til.md` with your preferred structure. If no template exis
 4) **Use it:**
 
 ```bash
-docmgr add --ticket MEN-XXXX --doc-type til --title "TIL — WebSocket Reconnection"
+docmgr doc add --ticket MEN-XXXX --doc-type til --title "TIL — WebSocket Reconnection"
 ```
 
 **Common custom doc types teams add:**
@@ -407,7 +407,7 @@ docmgr add --ticket MEN-XXXX --doc-type til --title "TIL — WebSocket Reconnect
 1) **Create ticket workspace:**
 
 ```bash
-docmgr create-ticket --ticket MIGRATE-001 --title "Existing Docs" --topics migration
+docmgr ticket create-ticket --ticket MIGRATE-001 --title "Existing Docs" --topics migration
 ```
 
 2) **Move files into ticket directory:**
@@ -455,7 +455,7 @@ Your repository now has:
 **What's next?**
 - Set up CI (see [Part 2](#part-2-ci-integration-🔧))
 - Share setup with team
-- Create first ticket: `docmgr create-ticket`
+- Create first ticket: `docmgr ticket create-ticket`
 
 ---
 
@@ -590,7 +590,7 @@ doc-report:
         
         echo ""
         echo "=== Recent Activity (Last 7 Days) ==="
-        docmgr search --updated-since "7 days ago"
+        docmgr doc search --updated-since "7 days ago"
 ```
 
 ---
@@ -612,10 +612,10 @@ doc-report:
 ### Use Search in Reviews
 ```bash
 # During code review: find design context
-docmgr search --file path/to/changed-file.go
+docmgr doc search --file path/to/changed-file.go
 
 # During architecture review: find related docs
-docmgr search --query "authentication" --doc-type design-doc
+docmgr doc search --query "authentication" --doc-type design-doc
 ```
 
 ### Treat Doctor Warnings as Tech Debt
@@ -632,7 +632,7 @@ docmgr search --query "authentication" --doc-type design-doc
 ### Use Tasks and Changelog
 ```bash
 # Encourage consistent tracking
-docmgr tasks add --ticket T --text "Task description"
+docmgr task add --ticket T --text "Task description"
 docmgr changelog update --ticket T --entry "What changed"
 ```
 

--- a/pkg/doc/docmgr-how-to-use.md
+++ b/pkg/doc/docmgr-how-to-use.md
@@ -133,8 +133,8 @@ This creates:
 ```
 ttmp/
 ├── vocabulary.yaml     # Defines topics/docTypes (used for validation warnings)
-├── _templates/         # Document templates (used by 'docmgr add')
-├── _guidelines/        # Writing guidelines (see 'docmgr guidelines')
+├── _templates/         # Document templates (used by 'docmgr doc add')
+├── _guidelines/        # Writing guidelines (see 'docmgr doc guidelines')
 └── .docmgrignore       # Files to exclude from validation
 ```
 
@@ -179,7 +179,7 @@ If you see these, initialization succeeded!
 ## 3. Create Your First Ticket [BASIC]
 
 ```bash
-docmgr create-ticket --ticket MEN-4242 \
+docmgr ticket create-ticket --ticket MEN-4242 \
   --title "Normalize chat API paths and WebSocket lifecycle" \
   --topics chat,backend,websocket
 ```
@@ -222,9 +222,9 @@ The `index.md` file is your ticket's single entry point. It:
 Add documents to organize your thinking:
 
 ```bash
-docmgr add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
-docmgr add --ticket MEN-4242 --doc-type reference --title "Chat WebSocket Lifecycle"
-docmgr add --ticket MEN-4242 --doc-type playbook --title "Smoke Tests for Chat"
+docmgr doc add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
+docmgr doc add --ticket MEN-4242 --doc-type reference --title "Chat WebSocket Lifecycle"
+docmgr doc add --ticket MEN-4242 --doc-type playbook --title "Smoke Tests for Chat"
 ```
 
 **What happens:**
@@ -240,7 +240,7 @@ docmgr add --ticket MEN-4242 --doc-type playbook --title "Smoke Tests for Chat"
 - `playbook` — Test procedures, operational runbooks
 - Custom types are allowed and create their own subdirectory (e.g., `til/`, `analysis/`)
 
-> **Tip:** Want structure guidance? Run: `docmgr guidelines --doc-type design-doc`
+> **Tip:** Want structure guidance? Run: `docmgr doc guidelines --doc-type design-doc`
 
 ---
 
@@ -250,16 +250,16 @@ Find docs by content or metadata:
 
 ```bash
 # Full-text search
-docmgr search --query "WebSocket"
+docmgr doc search --query "WebSocket"
 
 # Filter by metadata
-docmgr search --query "API" --topics backend --doc-type design-doc
+docmgr doc search --query "API" --topics backend --doc-type design-doc
 
 # Find docs that reference a code file (reverse lookup)
-docmgr search --file backend/api/register.go
+docmgr doc search --file backend/api/register.go
 
 # Find docs referencing any file in a directory
-docmgr search --dir backend/api/
+docmgr doc search --dir backend/api/
 ```
 
 **Common usecases:**
@@ -359,7 +359,7 @@ docmgr add --ticket $TICKET --doc-type playbook --title "Smoke Tests"
 
 ## 7. Relating Files to Docs [INTERMEDIATE]
 
-Bidirectional linking between documentation and code is one of docmgr's most powerful features. By relating code files to docs with explanatory notes, you create a navigation map that answers two critical questions: "What's the design for this code file?" (code review context) and "Which code implements this design?" (implementation reference). The `docmgr relate` command manages these relationships in frontmatter, while `docmgr search --file` provides instant reverse lookup from any code file to its related documentation.
+Bidirectional linking between documentation and code is one of docmgr's most powerful features. By relating code files to docs with explanatory notes, you create a navigation map that answers two critical questions: "What's the design for this code file?" (code review context) and "Which code implements this design?" (implementation reference). The `docmgr doc relate` command manages these relationships in frontmatter, while `docmgr doc search --file` provides instant reverse lookup from any code file to its related documentation.
 
 ### The Workflow
 
@@ -437,18 +437,18 @@ Use the `tasks` commands to track the concrete steps for your ticket directly in
 
 ```bash
 # List tasks with indexes
-docmgr tasks list --ticket MEN-4242
+docmgr task list --ticket MEN-4242
 
 # Add a new task
-docmgr tasks add --ticket MEN-4242 --text "Update API docs for /chat/v2"
+docmgr task add --ticket MEN-4242 --text "Update API docs for /chat/v2"
 
 # Check / uncheck by id
-docmgr tasks check   --ticket MEN-4242 --id 1
-docmgr tasks uncheck --ticket MEN-4242 --id 1
+docmgr task check   --ticket MEN-4242 --id 1
+docmgr task uncheck --ticket MEN-4242 --id 1
 
 # Edit and remove
-docmgr tasks edit   --ticket MEN-4242 --id 2 --text "Align frontend routes with backend"
-docmgr tasks remove --ticket MEN-4242 --id 3
+docmgr task edit   --ticket MEN-4242 --id 2 --text "Align frontend routes with backend"
+docmgr task remove --ticket MEN-4242 --id 3
 ```
 
 Tasks are standard Markdown checkboxes (`- [ ]` / `- [x]`). The commands only edit the specific task line, preserving the rest of the file.
@@ -458,7 +458,7 @@ Tasks are standard Markdown checkboxes (`- [ ]` / `- [x]`). The commands only ed
 - Canonical, machine‑readable checklist for the ticket (Markdown checkboxes)
 - Tracks day‑to‑day execution; keep it current as tasks start/finish
 - Break work into small, actionable items; optionally tag owners inline
-- Use the `docmgr tasks` commands to add/check/edit/remove without manual formatting
+- Use the `docmgr task` commands to add/check/edit/remove without manual formatting
 
 ## 11. Check Workspace Status
 
@@ -572,18 +572,18 @@ Use the `tasks` commands to track the concrete steps for your ticket directly in
 
 ```bash
 # List tasks with indexes
-docmgr tasks list --ticket MEN-4242
+docmgr task list --ticket MEN-4242
 
 # Add a new task
-docmgr tasks add --ticket MEN-4242 --text "Update API docs for /chat/v2"
+docmgr task add --ticket MEN-4242 --text "Update API docs for /chat/v2"
 
 # Check / uncheck by id
-docmgr tasks check   --ticket MEN-4242 --id 1
-docmgr tasks uncheck --ticket MEN-4242 --id 1
+docmgr task check   --ticket MEN-4242 --id 1
+docmgr task uncheck --ticket MEN-4242 --id 1
 
 # Edit and remove
-docmgr tasks edit   --ticket MEN-4242 --id 2 --text "Align frontend routes with backend"
-docmgr tasks remove --ticket MEN-4242 --id 3
+docmgr task edit   --ticket MEN-4242 --id 2 --text "Align frontend routes with backend"
+docmgr task remove --ticket MEN-4242 --id 3
 ```
 
 Tasks are standard Markdown checkboxes (`- [ ]` / `- [x]`). The commands only edit the specific task line, preserving the rest of the file.
@@ -593,7 +593,7 @@ Tasks are standard Markdown checkboxes (`- [ ]` / `- [x]`). The commands only ed
 - Canonical, machine‑readable checklist for the ticket (Markdown checkboxes)
 - Tracks day‑to‑day execution; keep it current as tasks start/finish
 - Break work into small, actionable items; optionally tag owners inline
-- Use the `docmgr tasks` commands to add/check/edit/remove without manual formatting
+- Use the `docmgr task` commands to add/check/edit/remove without manual formatting
 
 ## 11. Check Workspace Status
 

--- a/pkg/doc/how-to-work-on-any-ticket.md
+++ b/pkg/doc/how-to-work-on-any-ticket.md
@@ -1,0 +1,94 @@
+---
+Title: How to Work on Any Ticket with docmgr
+Slug: how-to-work-on-any-ticket
+Short: Step-by-step checklist for taking over any ticket workspace and keeping docmgr metadata aligned.
+Topics:
+- docmgr
+- workflow
+- onboarding
+- tickets
+IsTemplate: false
+IsTopLevel: true
+ShowPerDefault: true
+SectionType: Tutorial
+---
+
+# How to Work on Any Ticket with docmgr
+
+Whenever you inherit ticket `<TICKET-ID>` inside repository `<REPO-PATH>`, follow this playbook to get oriented, understand the current context, and keep the workspace in a compliant state. Every section builds on the previous one so you can ramp up quickly without dropping important metadata.
+
+## Step 0: Confirm the Workspace and Refresh docmgr Basics
+
+Before touching ticket files, confirm that you can run docmgr at the repository root. This ensures the help system is available and that the ticket metadata already exists.
+
+```bash
+cd <REPO-PATH>
+
+docmgr help how-to-use
+docmgr ticket list --ticket <TICKET-ID>
+docmgr doc list --ticket <TICKET-ID>
+docmgr task list --ticket <TICKET-ID>
+```
+
+If any command fails, fix the repository setup (see `docmgr help how-to-setup`) before proceeding.
+
+## Step 1: Review the Ticket Source Material
+
+Read all existing documentation in order so you understand why the ticket exists and what has already been attempted.
+
+1. Open the ticket index (typically `ttmp/<TICKET-ID>/index.md`) for the canonical summary.
+2. Inspect implementation diaries under `log/`, reading entries chronologically to catch historical context.
+3. Review the current `tasks.md` and `changelog.md` to see outstanding work and completed changes.
+4. Skim any background docs referenced by `docmgr doc list --ticket <TICKET-ID>` and note prerequisites or dependencies.
+
+## Step 2: Start with the Highest-Priority Tasks
+
+Always begin with the next unchecked task so progress stays orderly. Use the CLI to see and update task status as you work.
+
+```bash
+docmgr task list --ticket <TICKET-ID>
+docmgr task check --ticket <TICKET-ID> --id <TASK-ID>
+```
+
+Update the list as soon as you complete a meaningful unit of work and capture any new subtasks that emerge.
+
+## Step 3: Keep Files and the Changelog in Sync
+
+Every modification must be traceable. Relate files immediately after edits and log the change so future maintainers know what happened and why.
+
+```bash
+docmgr doc relate --ticket <TICKET-ID> \
+  --file-note "/ABS/PATH/TO/FILE:Why this file matters right now"
+
+docmgr changelog update --ticket <TICKET-ID> \
+  --entry "What changed and why" \
+  --file-note "/ABS/PATH/TO/FILE:Reason"
+```
+
+Use absolute paths for clarity, and group related changes into a single changelog entry with multiple `--file-note` values if needed.
+
+## Step 4: Maintain an Implementation Diary
+
+After each significant step, jot down what you tried, what succeeded or failed, and what to do next. Append to the active diary in `log/` or create a new note under `log/various/` if no diary exists yet. These entries become the institutional memory for the ticket.
+
+## Step 5: Capture Repo-Specific Intelligence
+
+Document any local setup, build commands, unusual comparison steps, or environment switches that apply to this repository. Add these notes to the ticket workspace (often `various/` or a dedicated reference doc) so the next person can reproduce your environment without guesswork.
+
+## Step 6: Track Known Issues and Immediate Focus
+
+Keep a running list of blockers, gaps, and temporary workarounds. Update it whenever you discover a new risk so planning conversations have an up-to-date source of truth. Mention follow-up tasks if they cannot be addressed immediately.
+
+## docmgr Helpers at a Glance
+
+Re-run the status and metadata commands whenever you context-switch to ensure nothing drifted:
+
+```bash
+docmgr status --summary-only
+docmgr ticket list
+docmgr meta update --ticket <TICKET-ID> --field Status --value active
+```
+
+## Where to Go Next
+
+After finishing this checklist, return to the task list, confirm priorities with the ticket owner, and continue iterating through tasks, file relations, changelog entries, and diary updates. This loop keeps every ticket workspace healthy and auditable.

--- a/pkg/doc/templates-and-guidelines.md
+++ b/pkg/doc/templates-and-guidelines.md
@@ -35,11 +35,11 @@ These folders are part of your repository so your team can customize house style
 
 ## How They’re Used in the CLI
 
-- `docmgr guidelines --doc-type <type> --output markdown`
+- `docmgr doc guidelines --doc-type <type> --output markdown`
   - Shows the guideline text for a given doc type
   - If `ttmp/_guidelines/<type>.md` exists, it is used; otherwise the embedded default is shown
 
-- `docmgr add --ticket <ticket> --doc-type <type> --title <title>`
+- `docmgr doc add --ticket <ticket> --doc-type <type> --title <title>`
   - Creates a new file with frontmatter
   - If `ttmp/_templates/<type>.md` exists, the body is rendered from the template with variable substitution (for example, `{{TITLE}}`, `{{TICKET}}`, `{{TOPICS}}`, `{{OWNERS}}`)
 
@@ -102,10 +102,10 @@ Explain the “why” behind decisions; enable future readers to re-derive conte
 ## Frequently Asked Questions
 
 Q: Do templates enforce structure automatically?
-A: Yes, when a matching template exists under `ttmp/_templates/`, `docmgr add` will render the body with variable substitution.
+A: Yes, when a matching template exists under `ttmp/_templates/`, `docmgr doc add` will render the body with variable substitution.
 
 Q: Any guidance for RelatedFiles?
-A: Prefer adding a short rationale note per file when possible. Use `docmgr relate --file-note "path:why it matters"` to capture the context.
+A: Prefer adding a short rationale note per file when possible. Use `docmgr doc relate --file-note "path:why it matters"` to capture the context.
 
 Q: How should we maintain changelogs?
 A: Capture decisions and progress in `changelog.md`. Use `docmgr changelog update` to append dated entries and optionally include related files with notes.
@@ -114,6 +114,6 @@ Q: Can guidelines differ between teams?
 A: Yes. Start with shared defaults and layer team-specific files in `ttmp/_guidelines/`.
 
 Q: How do I preview guidelines?
-A: Run `docmgr guidelines --doc-type <type> --output markdown`.
+A: Run `docmgr doc guidelines --doc-type <type> --output markdown`.
 
 

--- a/ttmp/2025/11/18/DOCMGR-CODE-REVIEW-code-review-docmgr-codebase/analysis/11-intent-and-status-fields-analysis.md
+++ b/ttmp/2025/11/18/DOCMGR-CODE-REVIEW-code-review-docmgr-codebase/analysis/11-intent-and-status-fields-analysis.md
@@ -1,0 +1,219 @@
+---
+Title: Intent and Status Fields Analysis
+Ticket: DOCMGR-CODE-REVIEW
+Status: active
+Topics:
+    - docmgr
+    - code-review
+DocType: analysis
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: Analysis of Intent and Status fields: how they're defined, validated, set, and modified in docmgr. Intent uses controlled vocabulary; Status is free-form.
+LastUpdated: 2025-11-19T14:14:54.016246947-05:00
+---
+
+# Intent and Status Fields Analysis
+
+## Overview
+
+This document analyzes how `Intent` and `Status` fields are defined, validated, and managed for tickets and documents in docmgr. These fields serve different purposes and have different validation mechanisms.
+
+## Intent Field
+
+### Definition and Purpose
+
+The `Intent` field indicates the longevity expectation for documentation:
+- **Purpose**: Distinguishes between long-term documentation (should be maintained) and temporary documentation (for active work)
+- **Type**: Controlled vocabulary (managed via `vocabulary.yaml`)
+- **Field Location**: Both tickets (index.md) and individual documents
+
+### Available Values
+
+Currently defined in `vocabulary.yaml`:
+- `long-term`: Long-term documentation that should be maintained
+
+### Default Values
+
+1. **When creating tickets** (`create-ticket` command):
+   - Checks workspace config defaults first (`cfg.Defaults.Intent`)
+   - Falls back to `"long-term"` if not configured
+   - See: ```142:147:docmgr/pkg/commands/create_ticket.go```
+
+2. **When creating documents** (`doc add` command):
+   - Inherits from ticket's index.md `Intent` field
+   - If ticket intent is empty, defaults to `"long-term"`
+   - Can be overridden via `--intent` flag
+   - See: ```215:221:docmgr/pkg/commands/add.go```
+
+### How Intent is Set/Modified
+
+1. **During creation**:
+   ```bash
+   # Via config defaults (for tickets)
+   # Set in .ttmp.yaml:
+   defaults:
+     intent: long-term
+   
+   # Via command flag (for documents)
+   docmgr doc add --ticket MEN-XXXX --doc-type design-doc --title "..." --intent long-term
+   ```
+
+2. **After creation**:
+   ```bash
+   # Update via meta update command
+   docmgr meta update --ticket MEN-XXXX --field Intent --value long-term
+   docmgr meta update --doc path/to/doc.md --field Intent --value long-term
+   ```
+
+3. **Via vocabulary management**:
+   ```bash
+   # Add new intent values to vocabulary
+   docmgr vocab add --category intent --slug short-term --description "Temporary documentation for active work"
+   ```
+
+### Validation
+
+- **Vocabulary validation**: The `doctor` command checks if intent values exist in vocabulary.yaml
+- **Warning level**: Unknown intent values generate warnings (not errors)
+- **See**: ```318:334:docmgr/pkg/commands/doctor.go```
+
+### Code References
+
+- Model definition: ```75:75:docmgr/pkg/models/document.go```
+- Vocabulary structure: ```149:153:docmgr/pkg/models/document.go```
+- Default handling in create_ticket: ```142:147:docmgr/pkg/commands/create_ticket.go```
+- Default handling in add: ```215:221:docmgr/pkg/commands/add.go```
+- Update handling: ```208:209:docmgr/pkg/commands/meta_update.go```
+
+## Status Field
+
+### Definition and Purpose
+
+The `Status` field indicates the current state of a ticket or document:
+- **Purpose**: Tracks workflow state (active, draft, review, complete, etc.)
+- **Type**: Free-form string (NOT managed via vocabulary)
+- **Field Location**: Both tickets (index.md) and individual documents
+
+### Available Values
+
+Status is **not constrained** by vocabulary. Common values found in the codebase:
+- `active`: Ticket/document is actively being worked on
+- `draft`: Document is in draft state
+- `review`: Document is ready for review
+- `complete`: Work is finished
+- `needs-review`: Document needs review
+- `archived`: Document/ticket is archived
+
+**Note**: These are examples only - any string value is accepted.
+
+### Default Values
+
+1. **When creating tickets** (`create-ticket` command):
+   - Hardcoded to `"active"` (no config override available)
+   - See: ```139:139:docmgr/pkg/commands/create_ticket.go```
+
+2. **When creating documents** (`doc add` command):
+   - Inherits from ticket's index.md `Status` field
+   - Can be overridden via `--status` flag
+   - See: ```210:213:docmgr/pkg/commands/add.go```
+
+### How Status is Set/Modified
+
+1. **During creation**:
+   ```bash
+   # Via command flag (for documents)
+   docmgr doc add --ticket MEN-XXXX --doc-type design-doc --title "..." --status draft
+   ```
+
+2. **After creation**:
+   ```bash
+   # Update via meta update command
+   docmgr meta update --ticket MEN-XXXX --field Status --value active
+   docmgr meta update --doc path/to/doc.md --field Status --value review
+   
+   # Update all documents of a specific type under a ticket
+   docmgr meta update --ticket MEN-XXXX --doc-type design-doc --field Status --value review
+   ```
+
+3. **Manual editing**: Status can be edited directly in YAML frontmatter
+
+### Validation
+
+- **Presence check**: The `doctor` command warns if Status is empty (but doesn't fail validation)
+- **No vocabulary validation**: Status values are NOT validated against vocabulary
+- **No enum constraints**: Any string value is accepted
+- **See**: ```268:275:docmgr/pkg/commands/doctor.go```
+
+### Code References
+
+- Model definition: ```72:72:docmgr/pkg/models/document.go```
+- Default in create_ticket: ```139:139:docmgr/pkg/commands/create_ticket.go```
+- Default handling in add: ```210:213:docmgr/pkg/commands/add.go```
+- Update handling: ```194:195:docmgr/pkg/commands/meta_update.go```
+- Status display: ```312:314:docmgr/pkg/commands/status.go```
+
+## Key Differences
+
+| Aspect | Intent | Status |
+|--------|--------|--------|
+| **Vocabulary managed** | ✅ Yes | ❌ No |
+| **Default value** | `"long-term"` | `"active"` (tickets only) |
+| **Configurable default** | ✅ Yes (via .ttmp.yaml) | ❌ No |
+| **Validation** | ✅ Warns on unknown values | ⚠️ Only checks for presence |
+| **Enum constraints** | ✅ Yes (via vocabulary) | ❌ No (free-form) |
+| **Can be empty** | ✅ Yes (defaults applied) | ⚠️ Warns if empty |
+
+## Recommendations
+
+### For Intent
+
+1. **Add common intent values to vocabulary**:
+   - Consider adding `short-term` or `temporary` for experimental docs
+   - Document intent values in team guidelines
+
+2. **Use config defaults**:
+   - Set default intent in `.ttmp.yaml` for consistency:
+     ```yaml
+     defaults:
+       intent: long-term
+     ```
+
+### For Status
+
+1. **Consider vocabulary management**:
+   - Status is currently free-form, which allows flexibility but may lead to inconsistency
+   - Consider adding status to vocabulary if standardization is desired
+   - Alternatively, document common status values in team guidelines
+
+2. **Document common workflows**:
+   - Document typical status transitions (draft → review → active → complete)
+   - Provide examples in documentation
+
+## Implementation Notes
+
+### Intent Implementation
+
+- Intent values are stored in `vocabulary.yaml` under the `intent` key
+- Vocabulary is loaded and validated by the `doctor` command
+- Unknown intent values generate warnings but don't prevent document creation
+- Intent can be managed via `docmgr vocab` commands
+
+### Status Implementation
+
+- Status is a simple string field with no vocabulary constraints
+- Status defaults are hardcoded in `create_ticket.go` (always `"active"`)
+- Status can be filtered in list/search commands (`--status` flag)
+- Status is displayed in status command output
+
+## Related Commands
+
+- `docmgr doc add`: Create documents with intent/status flags
+- `docmgr meta update`: Update intent/status fields
+- `docmgr vocab add`: Add new intent values to vocabulary
+- `docmgr vocab list`: List available intent values
+- `docmgr doctor`: Validate intent values against vocabulary
+- `docmgr list --status`: Filter by status value
+- `docmgr search --status`: Search by status value

--- a/ttmp/2025/11/18/DOCMGR-CODE-REVIEW-code-review-docmgr-codebase/reference/04-debate-format-and-candidates-workflow-improvements.md
+++ b/ttmp/2025/11/18/DOCMGR-CODE-REVIEW-code-review-docmgr-codebase/reference/04-debate-format-and-candidates-workflow-improvements.md
@@ -1,0 +1,56 @@
+---
+Title: Debate Format and Candidates - Workflow Improvements
+Ticket: DOCMGR-CODE-REVIEW
+Status: active
+Topics:
+    - docmgr
+    - code-review
+DocType: reference
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T14:20:10.940651889-05:00
+---
+
+---
+Title: Debate Format and Candidates - Workflow Improvements
+Ticket: DOCMGR-CODE-REVIEW
+Status: draft
+Topics:
+  - docmgr
+  - code-review
+DocType: reference
+Intent: long-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Debate Format and Candidates - Workflow Improvements
+
+## Goal
+
+<!-- What is the purpose of this reference document? -->
+
+## Context
+
+<!-- Provide background context needed to use this reference -->
+
+## Quick Reference
+
+<!-- Provide copy/paste-ready content, API contracts, or quick-look tables -->
+
+## Usage Examples
+
+<!-- Show how to use this reference in practice -->
+
+## Related
+
+<!-- Link to related documents or resources -->

--- a/ttmp/2025/11/18/DOCMGR-CODE-REVIEW-code-review-docmgr-codebase/reference/05-debate-questions-workflow-improvements.md
+++ b/ttmp/2025/11/18/DOCMGR-CODE-REVIEW-code-review-docmgr-codebase/reference/05-debate-questions-workflow-improvements.md
@@ -1,0 +1,56 @@
+---
+Title: Debate Questions - Workflow Improvements
+Ticket: DOCMGR-CODE-REVIEW
+Status: active
+Topics:
+    - docmgr
+    - code-review
+DocType: reference
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T14:20:12.084692546-05:00
+---
+
+---
+Title: Debate Questions - Workflow Improvements
+Ticket: DOCMGR-CODE-REVIEW
+Status: draft
+Topics:
+  - docmgr
+  - code-review
+DocType: reference
+Intent: long-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Debate Questions - Workflow Improvements
+
+## Goal
+
+<!-- What is the purpose of this reference document? -->
+
+## Context
+
+<!-- Provide background context needed to use this reference -->
+
+## Quick Reference
+
+<!-- Provide copy/paste-ready content, API contracts, or quick-look tables -->
+
+## Usage Examples
+
+<!-- Show how to use this reference in practice -->
+
+## Related
+
+<!-- Link to related documents or resources -->

--- a/ttmp/2025/11/18/DOCMGR-REFACTOR-code-refactoring-hierarchical-commands-and-utilities/playbook/01-hello.md
+++ b/ttmp/2025/11/18/DOCMGR-REFACTOR-code-refactoring-hierarchical-commands-and-utilities/playbook/01-hello.md
@@ -1,0 +1,62 @@
+---
+Title: Hello
+Ticket: DOCMGR-REFACTOR
+Status: active
+Topics:
+    - docmgr
+    - refactoring
+    - architecture
+DocType: playbook
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T12:50:50.087502269-05:00
+---
+
+---
+Title: Hello
+Ticket: DOCMGR-REFACTOR
+Status: draft
+Topics:
+  - docmgr
+  - refactoring
+  - architecture
+DocType: playbook
+Intent: short-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Hello
+
+## Purpose
+
+<!-- What does this playbook accomplish? -->
+
+## Environment Assumptions
+
+<!-- What environment or setup is required? -->
+
+## Commands
+
+<!-- List of commands to execute -->
+
+```bash
+# Command sequence
+```
+
+## Exit Criteria
+
+<!-- What indicates success or completion? -->
+
+## Notes
+
+<!-- Additional context or warnings -->

--- a/ttmp/2025/11/18/DOCMGR-REFACTOR-code-refactoring-hierarchical-commands-and-utilities/playbook/02-hello.md
+++ b/ttmp/2025/11/18/DOCMGR-REFACTOR-code-refactoring-hierarchical-commands-and-utilities/playbook/02-hello.md
@@ -1,0 +1,62 @@
+---
+Title: Hello
+Ticket: DOCMGR-REFACTOR
+Status: active
+Topics:
+    - docmgr
+    - refactoring
+    - architecture
+DocType: playbook
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T12:56:57.786902502-05:00
+---
+
+---
+Title: Hello
+Ticket: DOCMGR-REFACTOR
+Status: draft
+Topics:
+  - docmgr
+  - refactoring
+  - architecture
+DocType: playbook
+Intent: short-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Hello
+
+## Purpose
+
+<!-- What does this playbook accomplish? -->
+
+## Environment Assumptions
+
+<!-- What environment or setup is required? -->
+
+## Commands
+
+<!-- List of commands to execute -->
+
+```bash
+# Command sequence
+```
+
+## Exit Criteria
+
+<!-- What indicates success or completion? -->
+
+## Notes
+
+<!-- Additional context or warnings -->

--- a/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/README.md
+++ b/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/README.md
@@ -1,0 +1,21 @@
+# Fix how-to-use tutorial: new verb structure
+
+This is the document workspace for ticket DOCMGR-DOC-VERBS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr add design-doc "My Design"`
+- Import sources: `docmgr import file path/to/doc.md`
+- Update metadata: `docmgr meta update --field Status --value review`

--- a/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/changelog.md
+++ b/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/changelog.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2025-11-19
+
+- Initial workspace created
+
+
+## 2025-11-19
+
+Audit CLI verbs and added reference mapping; added task to update tutorial
+
+### Related Files
+
+- /home/manuel/workspaces/2025-11-18/code-review-docmgr/docmgr/pkg/doc/docmgr-how-to-use.md — Source tutorial to update (verbs outdated)
+

--- a/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/index.md
+++ b/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/index.md
@@ -1,0 +1,74 @@
+---
+Title: 'Fix how-to-use tutorial: new verb structure'
+Ticket: DOCMGR-DOC-VERBS
+Status: active
+Topics:
+    - docmgr
+    - documentation
+    - cli
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T13:58:24.683790459-05:00
+---
+
+---
+Title: Fix how-to-use tutorial: new verb structure
+Ticket: DOCMGR-DOC-VERBS
+Status: draft
+Topics:
+  - docmgr
+  - documentation
+  - cli
+DocType: index
+Intent: short-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Fix how-to-use tutorial: new verb structure
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- docmgr
+- documentation
+- cli
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/reference/01-cli-verbs-mapping-old-vs-new.md
+++ b/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/reference/01-cli-verbs-mapping-old-vs-new.md
@@ -1,0 +1,95 @@
+---
+Title: 'CLI verbs mapping: old vs new'
+Ticket: DOCMGR-DOC-VERBS
+Status: active
+Topics:
+    - docmgr
+    - documentation
+    - cli
+DocType: reference
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: /home/manuel/workspaces/2025-11-18/code-review-docmgr/docmgr/pkg/doc/docmgr-how-to-use.md
+      Note: Source tutorial to update (verbs outdated)
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T13:58:29.134137645-05:00
+---
+
+
+---
+# CLI verbs mapping: old vs new
+
+## Purpose
+Align the “how-to-use” tutorial with the new grouped verb structure. This is the authoritative mapping to use when updating examples.
+
+## Mapping (Old → New)
+
+| Area               | Old                         | New                          | Notes |
+|--------------------|-----------------------------|------------------------------|-------|
+| Add document       | `docmgr add`                | `docmgr doc add`             | Doc operations live under `doc` |
+| Search             | `docmgr search`             | `docmgr doc search`          | Full-text/metadata search moved under `doc` |
+| Guidelines         | `docmgr guidelines`         | `docmgr doc guidelines`      | Guidelines grouped with docs |
+| Relate files       | `docmgr relate`             | `docmgr doc relate`          | File relations are doc-scoped |
+| Create ticket      | `docmgr create-ticket`      | `docmgr ticket create-ticket`| Ticket operations under `ticket` |
+| List docs          | `docmgr list docs`          | `docmgr list docs`           | Preferred (also available: `docmgr doc docs`) |
+| List tickets       | `docmgr list tickets`       | `docmgr list tickets`        | Preferred (also available: `docmgr ticket tickets`) |
+| Status             | `docmgr status`             | `docmgr status`              | Unchanged |
+| Tasks              | `docmgr tasks …`            | `docmgr tasks …`             | Unchanged |
+| Metadata           | `docmgr meta update …`      | `docmgr meta update …`       | Unchanged |
+| Changelog          | `docmgr changelog update …` | `docmgr changelog update …`  | Unchanged |
+| Doctor             | `docmgr doctor …`           | `docmgr doctor …`            | Unchanged |
+| Init               | `docmgr init …`             | `docmgr init …`              | Unchanged |
+| Configure/Config   | `docmgr configure|config`   | `docmgr configure|config`    | Unchanged |
+
+## Updated examples to use in the tutorial
+
+### Create a ticket
+```bash
+docmgr ticket create-ticket --ticket MEN-4242 \
+  --title "Normalize chat API paths and WebSocket lifecycle" \
+  --topics chat,backend,websocket
+```
+
+### Add documents
+```bash
+docmgr doc add --ticket MEN-4242 --doc-type design-doc --title "Path Normalization Strategy"
+docmgr doc add --ticket MEN-4242 --doc-type reference --title "Chat WebSocket Lifecycle"
+docmgr doc add --ticket MEN-4242 --doc-type playbook  --title "Smoke Tests for Chat"
+```
+
+### Search
+```bash
+# Full-text search
+docmgr doc search --query "WebSocket"
+
+# Filter by metadata
+docmgr doc search --query "API" --topics backend --doc-type design-doc
+
+# Reverse lookup by file
+docmgr doc search --file backend/api/register.go
+```
+
+### Relate files to a document or ticket
+```bash
+# Relate to ticket index (repeat --file-note)
+docmgr doc relate --ticket MEN-4242 \
+  --file-note "backend/api/register.go:Registers API routes (normalization logic)" \
+  --file-note "backend/ws/manager.go:WebSocket lifecycle management"
+```
+
+### Guidelines
+```bash
+docmgr doc guidelines --doc-type design-doc
+```
+
+## Next steps (TODO)
+- [ ] Update `docmgr/pkg/doc/docmgr-how-to-use.md` to reflect the new verbs:
+  - Section 3 (Create Your First Ticket): use `docmgr ticket create-ticket`
+  - Section 4 (Add Documents): use `docmgr doc add`
+  - Section 5 (Search): use `docmgr doc search`
+  - Section 7 (Relating Files): use `docmgr doc relate`
+  - Section 12 (Guidelines mention): use `docmgr doc guidelines`
+- [ ] Open PR, link this reference, and announce in release notes

--- a/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/tasks.md
+++ b/ttmp/2025/11/19/DOCMGR-DOC-VERBS-fix-how-to-use-tutorial-new-verb-structure/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+
+- [ ] Update docmgr-how-to-use.md to new verbs (sections 3,4,5,7,12)

--- a/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/README.md
+++ b/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/README.md
@@ -1,0 +1,21 @@
+# Demo: Guidelines on Add
+
+This is the document workspace for ticket MEN-9998.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr add design-doc "My Design"`
+- Import sources: `docmgr import file path/to/doc.md`
+- Update metadata: `docmgr meta update --field Status --value review`

--- a/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/changelog.md
+++ b/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2025-11-19
+
+- Initial workspace created
+

--- a/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/index.md
+++ b/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/index.md
@@ -1,0 +1,71 @@
+---
+Title: 'Demo: Guidelines on Add'
+Ticket: MEN-9998
+Status: active
+Topics:
+    - docmgr
+    - guidelines
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T12:55:48.763966018-05:00
+---
+
+---
+Title: Demo: Guidelines on Add
+Ticket: MEN-9998
+Status: draft
+Topics:
+  - docmgr
+  - guidelines
+DocType: index
+Intent: short-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Demo: Guidelines on Add
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- docmgr
+- guidelines
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/playbook/01-demo-add-prints-guidelines.md
+++ b/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/playbook/01-demo-add-prints-guidelines.md
@@ -1,0 +1,60 @@
+---
+Title: Demo Add Prints Guidelines
+Ticket: MEN-9998
+Status: active
+Topics:
+    - docmgr
+    - guidelines
+DocType: playbook
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2025-11-19T12:55:56.124737564-05:00
+---
+
+---
+Title: Demo Add Prints Guidelines
+Ticket: MEN-9998
+Status: draft
+Topics:
+  - docmgr
+  - guidelines
+DocType: playbook
+Intent: short-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  
+LastUpdated: 2025-11-19
+---
+
+# Demo Add Prints Guidelines
+
+## Purpose
+
+<!-- What does this playbook accomplish? -->
+
+## Environment Assumptions
+
+<!-- What environment or setup is required? -->
+
+## Commands
+
+<!-- List of commands to execute -->
+
+```bash
+# Command sequence
+```
+
+## Exit Criteria
+
+<!-- What indicates success or completion? -->
+
+## Notes
+
+<!-- Additional context or warnings -->

--- a/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/tasks.md
+++ b/ttmp/2025/11/19/MEN-9998-demo-guidelines-on-add/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+


### PR DESCRIPTION
- Update command verbs for documentation consistency.
- Change command usage from `add` to `doc add`, `list` to `doc list`, 
  and `search` to `doc search`.
- Introduce aliases for backward compatibility in command usage.
- Enhance documentation to reflect these changes, ensuring 
  that the `how-to-use` tutorial is up-to-date.
- Improve clarity of command documentation by adding examples 
  and aligning with new verb structures.
- Add a new guide on how to work on any ticket.