### PR TITLE
Gate docs publishing to release tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,10 @@ jobs:
     name: Publish docs
     needs:
       - goreleaser-merge
-    if: ${{ false && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: read
+      id-token: write
     uses: go-go-golems/infra-tooling/.github/workflows/publish-docsctl.yml@main
     with:
       package_name: docmgr


### PR DESCRIPTION
## Summary

- follow-up for INFRA-006 after PR #41 merged before the docs-job gating fix landed
- enable the release-coupled publish-docs job only for v* tag push events
- add job-level OIDC permissions required by the reusable docsctl publisher

## Validation

- workflow-only change
- original docsctl export validation was recorded in INFRA-006

## Notes

The overall release workflow can still be manually dispatched, but the docs publishing job is now explicitly tag-push-only.